### PR TITLE
sysctl_tuner: log pid for sysctl modification

### DIFF
--- a/src/sysctl_tuner.bpf.c
+++ b/src/sysctl_tuner.bpf.c
@@ -72,6 +72,7 @@ int BPF_KPROBE(bpftune_sysctl, struct ctl_table_header *head,
 	net = (void *)root -
 		(__u64)__builtin_preserve_access_index(&dummy_net->sysctls) -
 		(__u64)__builtin_preserve_access_index(&dummy_ctl_table_set->dir);
+	event.pid = current_pid;
 	event.netns_cookie = get_netns_cookie(net);
 	if (event.netns_cookie == (unsigned long)-1)
 		return 0;

--- a/src/sysctl_tuner.c
+++ b/src/sysctl_tuner.c
@@ -80,8 +80,8 @@ void event_handler(struct bpftuner *tuner, struct bpftune_event *event,
 			 */
 			if (strstr(path, event->str)) {
 				bpftune_log(BPFTUNE_LOG_LEVEL,
-					    "user modified sysctl '%s' that tuner '%s' uses; disabling '%s' for namespace cookie %ld\n",
-					    event->str, t->name, t->name,
+					    "user (pid %ld) modified sysctl '%s' that tuner '%s' uses; disabling '%s' for namespace cookie %ld\n",
+					    event->pid, event->str, t->name, t->name,
 					    event->netns_cookie);
 				bpftuner_netns_fini(t, event->netns_cookie, BPFTUNE_MANUAL);
 				break;


### PR DESCRIPTION
good to know who is changing sysctls when we disable tuner; log pid.