### PR TITLE
Makefile: Replace -march=native with -march=x86-64

### DIFF
--- a/sample_tuner/Makefile
+++ b/sample_tuner/Makefile
@@ -37,7 +37,7 @@ installprefix = $(DESTDIR)/$(prefix)
 
 INSTALLPATH = $(installprefix)
 
-CFLAGS = -fPIC -Wall -Wextra -march=native -g -I../include -std=c99
+CFLAGS = -fPIC -Wall -Wextra -march=x86-64 -g -I../include -std=c99
 
 CFLAGS += -DBPFTUNE_VERSION='"$(BPFTUNE_VERSION)"' $(INCLUDES)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -55,7 +55,7 @@ endif
 VERSION = 0.1.3
 VERSION_SCRIPT  := libbpftune.map
 
-CFLAGS = -fPIC -Wall -Wextra -march=native -g -I../include -std=c99
+CFLAGS = -fPIC -Wall -Wextra -march=x86-64 -g -I../include -std=c99
 
 CFLAGS += -DBPFTUNE_VERSION='"$(BPFTUNE_VERSION)"' $(INCLUDES)
 

--- a/test/strategy/Makefile
+++ b/test/strategy/Makefile
@@ -38,7 +38,7 @@ installprefix = $(DESTDIR)/$(prefix)
 
 INSTALLPATH = $(installprefix)
 
-CFLAGS = -fPIC -Wall -Wextra -march=native -g -I../include -std=c99
+CFLAGS = -fPIC -Wall -Wextra -march=x86-64 -g -I../include -std=c99
 
 CFLAGS += -DBPFTUNE_VERSION='"$(BPFTUNE_VERSION)"' $(INCLUDES)
 


### PR DESCRIPTION
Currently when compiling this package into a repository it will result that people having issues running this package, because "-march=native" is used.
Replace it with a generic instruction and find further solution that compilation flags will be manually applied. 