### PR TITLE
make pkg: Fix SOURCES 'No such file or directory' error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,10 @@ test:	FORCE
 	cd test; make test
 
 pkg:    all
+	mkdir -p $(SRC_DIR) $(BUILD_DIR) $(BUILD_DIR)/$(prefix) $(LICENSEDIR);\
 	rm -fr $(SRC_DIR)/$(PKG_ARCHIVE)* ;\
 	git archive --format=tar --prefix=$(PKG_ARCHIVE)/ -o $(SRC_DIR)/$(PKG_ARCHIVE).tar HEAD;\
 	bzip2 $(SRC_DIR)/$(PKG_ARCHIVE).tar ; \
-	mkdir -p $(BUILD_DIR) $(BUILD_DIR)/$(prefix) $(LICENSEDIR);\
 	cp -pr LICENSE* $(LICENSEDIR) ;\
 	DESTDIR=$(BUILD_DIR) installprefix=$(BUILD_DIR)/$(prefix) rpmbuild --define "_topdir $(PKG_DIR)" -ba buildrpm/bpftune.spec
 


### PR DESCRIPTION
We should create a SOURCES directory for rpmbuild, reproduce the problem:

```bash
    # 1. Clean all
    $ rm -rf ~/rpmbuild

    # 2. Make package
    $ make pkg
    ...
    git archive --format=tar --prefix=`rpmspec -q --queryformat="%{NAME}-%{VERSION}\n" buildrpm/bpftune.spec | head -1`/ -o /home/rongtao/rpmbuild/SOURCES/`rpmspec -q --queryformat="%{NAME}-%{VERSION}\n" buildrpm/bpftune.spec | head -1`.tar HEAD
    fatal: could not open '/home/rongtao/rpmbuild/SOURCES/bpftune-0.1.tar' for writing: No such file or directory
```