### PR TITLE
bpftune: support a "no BTF" mode of operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 *.8
 *.skel.h
 *.skel.legacy.h
+*.skel.nobtf.h
 *.swp
 *.plist

--- a/include/bpftune/bpftune.h
+++ b/include/bpftune/bpftune.h
@@ -150,6 +150,13 @@ struct bpftuner_strategy {
 				 * strategy; if NULL, all */
 };
 
+enum bpftune_support_level {
+	BPFTUNE_SUPPORT_NONE,
+	BPFTUNE_SUPPORT_NOBTF,
+	BPFTUNE_SUPPORT_LEGACY,
+	BPFTUNE_SUPPORT_NORMAL
+};
+
 struct bpftuner {
 	unsigned int id;
 	enum bpftune_state state;
@@ -158,6 +165,7 @@ struct bpftuner {
 	void *handle;
 	const char *name;
 	struct bpf_object_skeleton *skeleton;
+	enum bpftune_support_level bpf_support;
 	bool bpf_legacy;
 	void *skel;
 	void *obj;

--- a/include/bpftune/libbpftune.h
+++ b/include/bpftune/libbpftune.h
@@ -138,139 +138,135 @@ void bpftuner_tunables_fini(struct bpftuner *tuner);
 
 /* need a macro in order to generate code for skeleton-specific struct */
 
-#define bpftuner_bpf_open(tuner_name, tuner) ({				     \
-	int __err = 0;							     \
+#define __bpftuner_bpf_open(tuner_name, tuner, suffix)			     \
 	do {								     \
-		struct tuner_name##_tuner_bpf *__skel;                       \
-		struct tuner_name##_tuner_bpf_legacy *__lskel;		     \
-									     \
-                __err = bpftune_cap_add();				     \
-		if (__err) break;					     \
-                tuner->name = #tuner_name;                                   \
-		tuner->bpf_legacy = bpftuner_bpf_legacy();		     \
-                if (!tuner->bpf_legacy) {				     \
-			tuner->skel = __skel = tuner_name##_tuner_bpf__open();\
-			__err = libbpf_get_error(tuner->skel);		     \
-			if (__err) break;				     \
-			tuner->skeleton = __skel->skeleton;		     \
-			__skel->bss->debug = bpftune_log_level() >= LOG_DEBUG;\
-			__skel->bss->bpftune_pid = getpid();		     \
-			__skel->bss->bpftune_learning_rate = bpftune_learning_rate;\
-			tuner->obj = __skel->obj;			     \
-			tuner->ring_buffer_map = __skel->maps.ring_buffer_map;\
-			tuner->netns_map = __skel->maps.netns_map;	     \
-		} else {						     \
-			tuner->skel = __lskel = tuner_name##_tuner_bpf_legacy__open();\
-			__err = libbpf_get_error(tuner->skel);		     \
-			if (__err) break;				     \
-			tuner->skeleton = __lskel->skeleton;		     \
-			__lskel->bss->debug = bpftune_log_level() >= LOG_DEBUG;\
-			__lskel->bss->bpftune_learning_rate = bpftune_learning_rate;\
-			__lskel->bss->bpftune_pid = getpid();		     \
-			tuner->obj = __lskel->obj;			     \
-			tuner->ring_buffer_map = __lskel->maps.ring_buffer_map;\
-			tuner->netns_map = __lskel->maps.netns_map;	     \
+		struct tuner_name##_tuner_##suffix *__skel;		     \
+		tuner->skel = __skel = tuner_name##_tuner_##suffix##__open();\
+		tuner->skeleton = __skel->skeleton;			     \
+		__skel->bss->debug = bpftune_log_level() >= LOG_DEBUG;	     \
+		__skel->bss->bpftune_pid = getpid();			     \
+		__skel->bss->bpftune_learning_rate = bpftune_learning_rate;  \
+		__skel->bss->tuner_id = bpftune_tuner_num();		     \
+		tuner->obj = __skel->obj;				     \
+		tuner->ring_buffer_map = __skel->maps.ring_buffer_map;	     \
+		tuner->netns_map = __skel->maps.netns_map;		     \
+	} while (0)
+
+#define bpftuner_bpf_open(tuner_name, tuner) ({				     \
+	int __err = bpftune_cap_add();					     \
+                                                                             \
+	if (!__err) {							     \
+		tuner->name = #tuner_name;				     \
+		tuner->bpf_support = bpftune_bpf_support();		     \
+		switch (tuner->bpf_support) {				     \
+		case BPFTUNE_SUPPORT_NORMAL:				     \
+			__bpftuner_bpf_open(tuner_name, tuner, bpf);	     \
+			break;						     \
+		case BPFTUNE_SUPPORT_LEGACY:				     \
+			__bpftuner_bpf_open(tuner_name, tuner, bpf_legacy);  \
+			break;						     \
+		case BPFTUNE_SUPPORT_NOBTF:				     \
+			__bpftuner_bpf_open(tuner_name, tuner, bpf_nobtf);   \
+			break;						     \
+		default:						     \
+			break;						     \
 		}							     \
-		bpftuner_bpf_set_autoload(tuner);			     \
-	} while (0);							     \
-	bpftune_cap_drop();						     \
+		bpftune_cap_drop();					     \
+	}								     \
+	__err = libbpf_get_error(tuner->skel);				     \
 	if (__err) {							     \
-		tuner->skel = NULL;					     \
-		bpftuner_bpf_destroy(tuner_name, tuner);		     \
-		bpftune_log_bpf_err(__err, #tuner_name " open bpf: %s\n");   \
+		bpftune_log_bpf_err(__err,				     \
+				    #tuner_name " open bpf: %s\n");	     \
 	}								     \
 	__err;								     \
-	})
+})
 
 #define bpftuner_bpf_destroy(tuner_name, tuner)				     \
 	do {								     \
-		if (!tuner->bpf_legacy)					     \
+		switch (tuner->bpf_support) {				     \
+		case BPFTUNE_SUPPORT_NORMAL:				     \
 			tuner_name##_tuner_bpf__destroy(tuner->skel);	     \
-		else							     \
+			break;						     \
+		case BPFTUNE_SUPPORT_LEGACY:				     \
 			tuner_name##_tuner_bpf_legacy__destroy(tuner->skel); \
-		tuner->skel = NULL;					     \
+			break;						     \
+		case BPFTUNE_SUPPORT_NOBTF:				     \
+			tuner_name##_tuner_bpf_nobtf__destroy(tuner->skel);  \
+			break;						     \
+		default:						     \
+			break;						     \
+		}							     \
 	} while (0)
 
 #define _bpftuner_bpf_load(tuner_name, tuner, optionals) ({		     \
-	int __err = 0;							     \
-	do {								     \
-		struct tuner_name##_tuner_bpf *__skel = tuner->skel;	     \
-		struct tuner_name##_tuner_bpf_legacy *__lskel = tuner->skel; \
+	int __err;							     \
 									     \
-		__err = __bpftuner_bpf_load(tuner, optionals);		     \
-		if (__err) {						     \
-			bpftuner_bpf_destroy(tuner_name, tuner);	     \
-			break;						     \
-		}							     \
-		if (!tuner->bpf_legacy)					     \
-			__skel->bss->tuner_id = bpftune_tuner_num();	     \
-		else							     \
-			__lskel->bss->tuner_id = bpftune_tuner_num();	     \
-	} while (0);							     \
+	__err = __bpftuner_bpf_load(tuner, optionals);			     \
+	if (__err)							     \
+		bpftuner_bpf_destroy(tuner_name, tuner);		     \
 	__err;								     \
-	})
+})
 
 #define bpftuner_bpf_load(tuner_name, tuner)				     \
 	_bpftuner_bpf_load(tuner_name, tuner, NULL)
 
 #define bpftuner_bpf_attach(tuner_name, tuner, optionals) ({		     \
-	int __err = 0;							     \
-	do {								     \
-                __err = __bpftuner_bpf_attach(tuner);			     \
-		if (__err && optionals != NULL) {			     \
-			bpftuner_bpf_fini(tuner);			     \
-			__err = bpftuner_bpf_open(tuner_name, tuner);	     \
-			if (!__err)					     \
-			__err = _bpftuner_bpf_load(tuner_name, tuner,	     \
-						   optionals);    	     \
-			if (!__err)					     \
+	int __err = __bpftuner_bpf_attach(tuner);			     \
+                                                                             \
+	if (__err && optionals != NULL) {				     \
+		bpftuner_bpf_fini(tuner);			 	     \
+		__err = bpftuner_bpf_open(tuner_name, tuner);	 	     \
+		if (!__err)						     \
+			__err = _bpftuner_bpf_load(tuner_name, tuner, optionals); \
+		if (!__err)						     \
 			__err = __bpftuner_bpf_attach(tuner);		     \
-		}							     \
-                if (__err)                                                   \
-			bpftuner_bpf_destroy(tuner_name, tuner);	     \
-	} while (0);							     \
+	}								     \
 	__err;								     \
-	})
+})
 
 #define bpftuner_bpf_init(tuner_name, tuner, optionals) ({		     \
-	int __err = 0;							     \
-	do {								     \
-		__err = bpftuner_bpf_open(tuner_name, tuner);		     \
-		if (!__err)						     \
+	int __err = bpftuner_bpf_open(tuner_name, tuner);		     \
+									     \
+	if (!__err)							     \
 		__err = bpftuner_bpf_load(tuner_name, tuner);		     \
-		if (!__err)						     \
-		__err = bpftuner_bpf_attach(tuner_name, tuner, optionals);   \
-	} while (0);							     \
+	if (!__err)							     \
+		bpftuner_bpf_attach(tuner_name, tuner, optionals);	     \
 	__err;								     \
-	})
+})
 
 
 #define bpftuner_bpf_var_set(tuner_name, tuner, var, val)		     \
 	do {								     \
 		struct tuner_name##_tuner_bpf *__skel = tuner->skel;	     \
                 struct tuner_name##_tuner_bpf_legacy *__lskel = tuner->skel; \
-		if (tuner->bpf_legacy)					     \
+		struct tuner_name##_tuner_bpf_nobtf *__nskel = tuner->skel;  \
+		switch (tuner->bpf_support) {				     \
+		case BPFTUNE_SUPPORT_NORMAL:				     \
 			__skel->bss->var = val;				     \
-		else							     \
+			break;						     \
+		case BPFTUNE_SUPPORT_LEGACY:				     \
 			__lskel->bss->var = val;			     \
+			break;						     \
+		case BPFTUNE_SUPPORT_NOBTF:				     \
+			__nskel->bss->var = val;			     \
+		default:						     \
+			break;						     \
+		}							     \
 		bpftune_log(LOG_DEBUG, "%s: set variable '%s' = '%ld'\n",    \
 			    #tuner_name, #var, (long)val);		     \
 	} while (0)
 
 #define bpftuner_bpf_var_get(tuner_name, tuner, var)			     \
-	(tuner->bpf_legacy ?						     \
+	(tuner->bpf_support == BPFTUNE_SUPPORT_NORMAL ?		     \
+	 ((struct tuner_name##_tuner_bpf *)tuner->skel)->bss->var :    \
+	 tuner->bpf_support == BPFTUNE_SUPPORT_LEGACY ?		     \
 	 ((struct tuner_name##_tuner_bpf_legacy *)tuner->skel)->bss->var :   \
-	 ((struct tuner_name##_tuner_bpf *)tuner->skel)->bss->var)
-
-enum bpftune_support_level {
-	BPFTUNE_NONE = -1,
-	BPFTUNE_LEGACY,
-	BPFTUNE_NORMAL
-};
+	 ((struct tuner_name##_tuner_bpf_nobtf *)tuner->skel)->bss->var)
 
 enum bpftune_support_level bpftune_bpf_support(void);
-void bpftuner_force_bpf_legacy(void);
-bool bpftuner_bpf_legacy(void);
+bool bpftune_have_vmlinux_btf(void);
+void bpftune_force_bpf_support(enum bpftune_support_level);
+
 int bpftuner_ring_buffer_map_fd(struct bpftuner *tuner);
 void *bpftune_ring_buffer_init(int ringbuf_map_fd, void *ctx);
 int bpftune_ring_buffer_poll(void *ring_buffer, int interval);

--- a/sample_tuner/Makefile
+++ b/sample_tuner/Makefile
@@ -92,9 +92,13 @@ $(BPF_OBJS): $(patsubst %.o,%.c,$(BPF_OBJS))
 		$(INCLUDES) -c $(patsubst %.o,%.c,$(@)) -o $(@);
 	$(CLANG) -g -D__TARGET_ARCH_$(SRCARCH) -DBPFTUNE_LEGACY -O2 -target bpf \
 		$(INCLUDES) -c $(patsubst %.o,%.c,$(@)) \
-		-o $(patsubst %.o,%.legacy.o,$(@))
+		-o $(patsubst %.o,%.legacy.o,$(@));
+	$(CLANG) -g -D__TARGET_ARCH_$(SRCARCH) -DBPFTUNE_NOBTF -DBPFTUNE_LEGACY -O2 -target bpf \
+		$(INCLUDES) -c $(patsubst %.o,%.c,$(@)) \
+		-o $(patsubst %.o,%.nobtf.o,$(@));
 
 $(BPF_SKELS): $(BPF_OBJS)
 	$(BPFTOOL) gen skeleton $(subst .skel.h,.bpf.o,$@) > $@ ;\
-	$(BPFTOOL) gen skeleton $(subst .skel.h,.bpf.legacy.o,$@) > $(subst .skel.h,.skel.legacy.h,$@)
+	$(BPFTOOL) gen skeleton $(subst .skel.h,.bpf.legacy.o,$@) > $(subst .skel.h,.skel.legacy.h,$@);\
+	$(BPFTOOL) gen skeleton $(subst .skel.h,.bpf.nobtf.o,$@) > $(subst .skel.h,.skel.nobtf.h,$@)
 

--- a/sample_tuner/sample_tuner.c
+++ b/sample_tuner/sample_tuner.c
@@ -21,6 +21,7 @@
 #include <bpftune/bpftune.h>
 #include "sample_tuner.skel.h"
 #include "sample_tuner.skel.legacy.h"
+#include "sample_tuner.skel.nobtf.h"
 
 int init(struct bpftuner *tuner)
 {

--- a/src/Makefile
+++ b/src/Makefile
@@ -94,9 +94,11 @@ BPF_TUNERS = $(patsubst %,%.bpf.o,$(TUNERS))
 
 BPF_OBJS = $(BPF_TUNERS) probe.bpf.o
 LEGACY_BPF_OBJS = $(patsubst %.bpf.o,%.bpf.legacy.o,$(BPF_OBJS))
+NOBTF_BPF_OBJS = $(patsubst %.bpf.o,%.bpf.nobtf.o,$(BPF_OBJS))
 
 BPF_SKELS = $(patsubst %,%.skel.h,$(TUNERS)) probe.skel.h
 LEGACY_BPF_SKELS = $(patsubst %.skel.h,%.skel.legacy.h,$(BPF_SKELS))
+NOBTF_BPF_SKELS = $(patsubst %.skel.h,%.skel.nobtf.h,$(BPF_SKELS))
 
 .DELETE_ON_ERROR:
 
@@ -107,7 +109,7 @@ all: analyze $(OPATH) $(OPATH)bpftune $(TUNER_LIBS)
 $(OPATH):
 	mkdir $(OPATH)
 	
-analyze: $(BPF_SKELS) $(LEGACY_BPF_SKELS)
+analyze: $(BPF_SKELS) $(LEGACY_BPF_SKELS) $(NOBTF_BPF_SKELS)
 	$(CLANG) --analyze $(INCLUDES) libbpftune.c bpftune.c $(TUNER_SRCS)
 clean:
 	$(call QUIET_CLEAN, bpftune)
@@ -146,13 +148,13 @@ $(OPATH)libbpftune.so: libbpftune.c ../include/bpftune/libbpftune.h $(OPATH)libb
 	rm -f $(@) ; \
 	ln -sr $(@).$(VERSION) $(@)
 
-$(TUNER_OBJS): $(BPF_SKELS) $(LEGACY_BPF_SKELS)
+$(TUNER_OBJS): $(BPF_SKELS) $(LEGACY_BPF_SKELS) $(NOBTF_BPF_SKELS)
 
 $(TUNER_LIBS): $(OPATH)libbpftune.so $(TUNER_OBJS)
 	$(CC) $(CFLAGS) -shared -o $(@) $(patsubst $(OPATH)%.so,%.c,$(@)) \
 		$(LDLIBS) -lbpftune $(LDFLAGS)
 
-$(OPATH)libbpftune.o: probe.skel.h probe.skel.legacy.h
+$(OPATH)libbpftune.o: probe.skel.h probe.skel.legacy.h probe.skel.nobtf.h
 	$(QUIET_CC)$(CC) $(CFLAGS) -c libbpftune.c -o $@
 
 $(OPATH)bpftune.o: $(OPATH)libbpftune.so
@@ -170,9 +172,17 @@ $(LEGACY_BPF_OBJS): $(patsubst %.legacy.o,%.c,$(LEGACY_BPF_OBJS))
 		$(INCLUDES) -c $(patsubst %.legacy.o,%.c,$(@)) \
 		-o $(@)
 
+$(NOBTF_BPF_OBJS): $(patsubst %.nobtf.o,%.c,$(NOBTF_BPF_OBJS))
+	$(CLANG) $(BPF_CFLAGS) -D__TARGET_ARCH_$(SRCARCH) -DBPFTUNE_NOBTF -O2 -target bpf \
+		$(INCLUDES) -c $(patsubst %.nobtf.o,%.c,$(@)) \
+		-o $(@)
+
 $(BPF_SKELS): $(BPF_OBJS)
 	$(BPFTOOL) gen skeleton $(subst .skel.h,.bpf.o,$@) > $@
 
 $(LEGACY_BPF_SKELS): $(LEGACY_BPF_OBJS)
 	$(BPFTOOL) gen skeleton $(subst .skel.legacy.h,.bpf.legacy.o,$@) > $(subst .skel.h,.skel.legacy.h,$@)
+
+$(NOBTF_BPF_SKELS): $(NOBTF_BPF_OBJS)
+	$(BPFTOOL) gen skeleton $(subst .skel.nobtf.h,.bpf.nobtf.o,$@) > $(subst .skel.h,.skel.nobtf.h,$@)
 

--- a/src/bpftune.c
+++ b/src/bpftune.c
@@ -253,17 +253,20 @@ static void do_usage(void)
 void print_support_level(enum bpftune_support_level support_level)
 {
 	switch (support_level) {
-	case BPFTUNE_NONE:
+	case BPFTUNE_SUPPORT_NONE:
 		bpftune_log(BPFTUNE_LOG_LEVEL, "bpftune is not supported\n");
 		break;
-	case BPFTUNE_LEGACY:
+	case BPFTUNE_SUPPORT_NOBTF:
+		bpftune_log(BPFTUNE_LOG_LEVEL, "bpftune works, but no BPF Type Format information (BTF) is available.  This means kernel data structure offsets may not match those at compile-time, and tuners may not operate as expected. This mode of operation is unsupported, and failures are expected, so be warned.\n");
+		break;
+	case BPFTUNE_SUPPORT_LEGACY:
 		bpftune_log(BPFTUNE_LOG_LEVEL, "bpftune works in legacy mode\n");
 		break;
-	case BPFTUNE_NORMAL:
+	case BPFTUNE_SUPPORT_NORMAL:
 		bpftune_log(BPFTUNE_LOG_LEVEL, "bpftune works fully\n");
 		break;
 	}
-	if (support_level > BPFTUNE_NONE) {
+	if (support_level > BPFTUNE_SUPPORT_NONE) {
 		bpftune_log(BPFTUNE_LOG_LEVEL, "bpftune %s per-netns policy (via netns cookie)\n",
 			    bpftune_netns_cookie_supported() ?
 			    "supports" : "does not support");
@@ -325,7 +328,7 @@ int main(int argc, char *argv[])
 			library_dir = optarg;
 			break;
 		case 'L':
-			bpftuner_force_bpf_legacy();
+			bpftune_force_bpf_support(BPFTUNE_SUPPORT_LEGACY);
 			break;
 		case 'r':
 			rate = atoi(optarg);
@@ -379,7 +382,7 @@ int main(int argc, char *argv[])
 
 	support_level = bpftune_bpf_support();
 	print_support_level(support_level);
-	if (support_level < BPFTUNE_LEGACY) {
+	if (support_level < BPFTUNE_SUPPORT_NOBTF) {
 		bpftune_log(BPFTUNE_LOG_LEVEL, "bpftune is not supported on this system; exiting\n");
 		return 1;
 	}

--- a/src/libbpftune.map
+++ b/src/libbpftune.map
@@ -21,8 +21,7 @@ LIBBPFTUNE_0.1.1 {
 		bpftune_tuner_num;
 		bpftune_bpf_support;
 		bpftuner_init;
-		bpftuner_force_bpf_legacy;
-		bpftuner_bpf_legacy;
+		bpftune_force_bpf_support;
 		__bpftuner_bpf_load;
 		__bpftuner_bpf_attach;
 		bpftuner_tunables_init;

--- a/src/neigh_table_tuner.bpf.c
+++ b/src/neigh_table_tuner.bpf.c
@@ -41,28 +41,28 @@ int BPF_PROG(bpftune_neigh_create, struct neigh_table *tbl,
 	if (!tbl_stats) {
 		struct tbl_stats new_tbl_stats = {};
 
-		new_tbl_stats.family = BPF_CORE_READ(tbl, family);
-		new_tbl_stats.entries = BPF_CORE_READ(tbl, entries.counter);
-		new_tbl_stats.max = BPF_CORE_READ(tbl, gc_thresh3);
+		new_tbl_stats.family = BPFTUNE_CORE_READ(tbl, family);
+		new_tbl_stats.entries = BPFTUNE_CORE_READ(tbl, entries.counter);
+		new_tbl_stats.max = BPFTUNE_CORE_READ(tbl, gc_thresh3);
 		if (dev) {
 			bpf_probe_read(&new_tbl_stats.dev, sizeof(new_tbl_stats.dev), dev);
-			new_tbl_stats.ifindex = BPF_CORE_READ(dev, ifindex);
+			new_tbl_stats.ifindex = BPFTUNE_CORE_READ(dev, ifindex);
 		}
 		bpf_map_update_elem(&tbl_map, &key, &new_tbl_stats, BPF_ANY);
 		tbl_stats = bpf_map_lookup_elem(&tbl_map, &key);
 		if (!tbl_stats)
 			return 0;
 	}
-	tbl_stats->entries = BPF_CORE_READ(tbl, entries.counter);
-	tbl_stats->gc_entries = BPF_CORE_READ(tbl, gc_entries.counter);
-	tbl_stats->max = BPF_CORE_READ(tbl, gc_thresh3);
+	tbl_stats->entries = BPFTUNE_CORE_READ(tbl, entries.counter);
+	tbl_stats->gc_entries = BPFTUNE_CORE_READ(tbl, gc_entries.counter);
+	tbl_stats->max = BPFTUNE_CORE_READ(tbl, gc_thresh3);
 
 	/* exempt from gc entries are not subject to space constraints, but
  	 * do take up table entries.
  	 */
 	if (NEARLY_FULL(tbl_stats->entries, tbl_stats->max)) {
-		struct neigh_parms *parms = BPF_CORE_READ(n, parms);
-		struct net *net = BPF_CORE_READ(parms, net.net);
+		struct neigh_parms *parms = BPFTUNE_CORE_READ(n, parms);
+		struct net *net = BPFTUNE_CORE_READ(parms, net.net);
 
 		event.tuner_id = tuner_id;
 		event.scenario_id = NEIGH_TABLE_FULL;

--- a/src/neigh_table_tuner.c
+++ b/src/neigh_table_tuner.c
@@ -24,6 +24,7 @@
 #include "neigh_table_tuner.h"
 #include "neigh_table_tuner.skel.h"
 #include "neigh_table_tuner.skel.legacy.h"
+#include "neigh_table_tuner.skel.nobtf.h"
 
 struct neigh_table_tuner_bpf *skel;
 

--- a/src/net_buffer_tuner.c
+++ b/src/net_buffer_tuner.c
@@ -5,6 +5,7 @@
 #include "net_buffer_tuner.h"
 #include "net_buffer_tuner.skel.h"
 #include "net_buffer_tuner.skel.legacy.h"
+#include "net_buffer_tuner.skel.nobtf.h"
 
 #include <unistd.h>
 

--- a/src/netns_tuner.c
+++ b/src/netns_tuner.c
@@ -21,6 +21,7 @@
 #include "netns_tuner.h"
 #include "netns_tuner.skel.h"
 #include "netns_tuner.skel.legacy.h"
+#include "netns_tuner.skel.nobtf.h"
 
 struct netns_tuner_bpf *skel;
 

--- a/src/probe.bpf.c
+++ b/src/probe.bpf.c
@@ -27,6 +27,8 @@ BPF_MAP_DEF(probe_hash_map, BPF_MAP_TYPE_HASH, __u64, __u64, 65536);
 /* probe kprobe/fentry */
 BPF_FENTRY(setup_net, struct net *net, struct user_namespace *user_ns)
 {
+	if (get_netns_cookie(net))
+		return 0;
 	return 0;
 }
 

--- a/src/route_table_tuner.bpf.c
+++ b/src/route_table_tuner.bpf.c
@@ -55,7 +55,7 @@ int BPF_KRETPROBE(bpftune_fib6_run_gc)
 
 	net = dst_net->net;
 
-	max_size = BPF_CORE_READ(net, ipv6.sysctl.ip6_rt_max_size);
+	max_size = BPFTUNE_CORE_READ(net, ipv6.sysctl.ip6_rt_max_size);
 	if (NEARLY_FULL(dst_net->entries, max_size)) {
 		struct bpftune_event event = {};
 		long old[3] = {};

--- a/src/route_table_tuner.c
+++ b/src/route_table_tuner.c
@@ -22,6 +22,7 @@
 #include "route_table_tuner.h"
 #include "route_table_tuner.skel.h"
 #include "route_table_tuner.skel.legacy.h"
+#include "route_table_tuner.skel.nobtf.h"
 
 struct route_table_tuner_bpf *skel;
 

--- a/src/sysctl_tuner.c
+++ b/src/sysctl_tuner.c
@@ -21,6 +21,7 @@
 #include <bpftune/bpftune.h>
 #include "sysctl_tuner.skel.h"
 #include "sysctl_tuner.skel.legacy.h"
+#include "sysctl_tuner.skel.nobtf.h"
 
 #include <errno.h>
 #include <string.h>

--- a/src/tcp_buffer_tuner.c
+++ b/src/tcp_buffer_tuner.c
@@ -5,6 +5,7 @@
 #include "tcp_buffer_tuner.h"
 #include "tcp_buffer_tuner.skel.h"
 #include "tcp_buffer_tuner.skel.legacy.h"
+#include "tcp_buffer_tuner.skel.nobtf.h"
 
 #include <bpftune/corr.h>
 

--- a/src/tcp_cong_tuner.bpf.c
+++ b/src/tcp_cong_tuner.bpf.c
@@ -164,7 +164,7 @@ int cong_tuner_sockops(struct bpf_sock_ops *ops)
 #else
 static __always_inline int get_sk_key(struct sock *sk, struct in6_addr *key)
 {
-	int family = BPF_CORE_READ(sk, sk_family);
+	int family = BPFTUNE_CORE_READ(sk, sk_family);
 
 	switch (family) {
 	case AF_INET:
@@ -201,16 +201,16 @@ int BPF_PROG(cong_retransmit, struct sock *sk, struct sk_buff *skb)
 	if (remote_host->retransmit_threshold)
 		return 0;
 
-	segs_out = BPF_CORE_READ(tp, segs_out);
-	total_retrans = BPF_CORE_READ(tp, total_retrans);
+	segs_out = BPFTUNE_CORE_READ(tp, segs_out);
+	total_retrans = BPFTUNE_CORE_READ(tp, total_retrans);
 
 	if (!retransmit_threshold(remote_host, segs_out, total_retrans))
                 return 0;
 
-	sin6->sin6_family = BPF_CORE_READ(sk, sk_family);
+	sin6->sin6_family = BPFTUNE_CORE_READ(sk, sk_family);
 	event.tuner_id = tuner_id;
 	event.scenario_id = id;
-	net = BPF_CORE_READ(sk, sk_net.net);
+	net = BPFTUNE_CORE_READ(sk, sk_net.net);
 	event.netns_cookie = get_netns_cookie(net);
 	if (event.netns_cookie < 0)
 		return 0;

--- a/test/strategy/Makefile
+++ b/test/strategy/Makefile
@@ -63,9 +63,11 @@ BPF_TUNERS = $(patsubst %,%.bpf.o,$(TUNERS))
 
 BPF_OBJS = $(BPF_TUNERS)
 LEGACY_BPF_OBJS = $(patsubst %.bpf.o,%.bpf.legacy.o,$(BPF_OBJS))
+NOBTF_BPF_OBJS = $(patsubst %.bpf.o,%.bpf.nobtf.o,$(BPF_OBJS))
 
 BPF_SKELS = $(patsubst %,%.skel.h,$(TUNERS))
 LEGACY_BPF_SKELS = $(patsubst %.skel.h,%.skel.legacy.h,$(BPF_SKELS))
+NOBTF_BPF_SKELS = $(patsubst %.skel.h,%.skel.nobtf.h,$(BPF_SKELS))
 
 .DELETE_ON_ERROR:
 
@@ -82,7 +84,7 @@ $(TUNER_LIBS): $(BPF_SKELS) $(TUNER_OBJS)
 	$(CC) $(CFLAGS) -shared -o $(@) $(patsubst %.so,%.c,$(@)) \
 		$(LDLIBS) -lbpftune $(LDFLAGS)
 
-$(TUNER_OBJS): $(BPF_SKELS) $(LEGACY_BPF_SKELS)
+$(TUNER_OBJS): $(BPF_SKELS) $(LEGACY_BPF_SKELS) $(NOBTF_BPF_SKELS)
 
 $(BPF_OBJS): $(patsubst %.o,%.c,$(BPF_OBJS))
 	$(CLANG) $(BPF_CFLAGS) -D__TARGET_ARCH_$(SRCARCH) -O2 -target bpf \
@@ -93,9 +95,17 @@ $(LEGACY_BPF_OBJS): $(patsubst %.legacy.o,%.c,$(LEGACY_BPF_OBJS))
 		$(INCLUDES) -c $(patsubst %.legacy.o,%.c,$(@)) \
 		-o $(@)
 
+$(NOBTF_BPF_OBJS): $(patsubst %.nobtf.o,%.c,$(NOBTF_BPF_OBJS))
+	$(CLANG) $(BPF_CFLAGS) -D__TARGET_ARCH_$(SRCARCH) -DBPFTUNE_NOBTF -O2 -target bpf \
+		$(INCLUDES) -c $(patsubst %.nobtf.o,%.c,$(@)) \
+		-o $(@)
+
 $(BPF_SKELS): $(BPF_OBJS)
 	$(BPFTOOL) gen skeleton $(subst .skel.h,.bpf.o,$@) > $@
 
 $(LEGACY_BPF_SKELS): $(LEGACY_BPF_OBJS)
 	$(BPFTOOL) gen skeleton $(subst .skel.legacy.h,.bpf.legacy.o,$@) > $(subst .skel.h,.skel.legacy.h,$@)
+
+$(NOBTF_BPF_SKELS): $(NOBTF_BPF_OBJS)
+	$(BPFTOOL) gen skeleton $(subst .skel.nobtf.h,.bpf.nobtf.o,$@) > $(subst .skel.h,.skel.nobtf.h,$@)
 

--- a/test/strategy/strategy_tuner.c
+++ b/test/strategy/strategy_tuner.c
@@ -21,6 +21,7 @@
 #include <bpftune/bpftune.h>
 #include "strategy_tuner.skel.h"
 #include "strategy_tuner.skel.legacy.h"
+#include "strategy_tuner.skel.nobtf.h"
 
 static int evaluate_A(struct bpftuner *tuner, struct bpftuner_strategy *strategy)
 {


### PR DESCRIPTION
on some systems BPF Type Format (BTF) info is not available.  Because we make extensive use of it, we need a separate set of BPF programs that work in a "no BTF" world; these cannot make use of Compile Once - Run Everywhere (CO-RE) relocations, so data structure offsets may be wrong for the running kernel, so warn the user.

Tuners cannot be supported in this mode because the likeliehood of such issues is nearly 100%; warn the user about this.

Reported-by: Stuart Shelton <https://github.com/srcshelton>