### PR TITLE
libbpftune: do not print error when signal received

### DIFF
--- a/src/libbpftune.c
+++ b/src/libbpftune.c
@@ -806,7 +806,9 @@ int bpftune_ring_buffer_poll(void *ring_buffer, int interval)
 	while (!ring_buffer_done) {
 		err = ring_buffer__poll(rb, interval);
 		if (err < 0) {
-			bpftune_log_bpf_err(err, "ring_buffer__poll: %s\n");
+			/* -EINTR means we got signal; don't report as error. */
+			if (err != -EINTR)
+				bpftune_log_bpf_err(err, "ring_buffer__poll: %s\n");
 			break;
 		}
 	}


### PR DESCRIPTION
when we get a signal during polling, we see

Aug 19 10:11:41 nixos-dell bpftune[7957]: ring_buffer__poll: Interrupted system call

This is not an error; it's just that the signal is delivered while we are polling, so skip error display for this case.

Reported by: Tungsten842 (https://github.com/Tungsten842)
Signed-off-by: Alan Maguire <alan.maguire@oracle.com>