### PR TITLE
bpftune: expose strategy_id to tuner bpf programs

### DIFF
--- a/include/bpftune/bpftune.bpf.h
+++ b/include/bpftune/bpftune.bpf.h
@@ -197,6 +197,7 @@ BPF_RINGBUF(ring_buffer_map, 128 * 1024);
 BPF_MAP_DEF(netns_map, BPF_MAP_TYPE_HASH, __u64, __u64, 65536);
 
 unsigned int tuner_id;
+unsigned int strategy_id;
 unsigned int bpftune_pid;
 /* init_net value used for older kernels since __ksym does not work */
 unsigned long bpftune_init_net;

--- a/include/bpftune/bpftune.h
+++ b/include/bpftune/bpftune.h
@@ -146,6 +146,7 @@ struct bpftuner_strategy {
 	/* return a number to compare with other strategies */
 	long double (*evaluate)(struct bpftuner *tuner, struct bpftuner_strategy *strategy);
 	unsigned long timeout;	/* time in seconds until evaluation */
+	unsigned int id;	/* strategy id */
 	const char **bpf_progs;	/* programs to load in BPF skeleton for this
 				 * strategy; if NULL, all */
 };

--- a/include/bpftune/libbpftune.h
+++ b/include/bpftune/libbpftune.h
@@ -147,6 +147,8 @@ void bpftuner_tunables_fini(struct bpftuner *tuner);
 		__skel->bss->bpftune_pid = getpid();			     \
 		__skel->bss->bpftune_learning_rate = bpftune_learning_rate;  \
 		__skel->bss->tuner_id = bpftune_tuner_num();		     \
+		if (tuner->strategy)					     \
+			__skel->bss->strategy_id = tuner->strategy->id;	     \
 		tuner->obj = __skel->obj;				     \
 		tuner->ring_buffer_map = __skel->maps.ring_buffer_map;	     \
 		tuner->netns_map = __skel->maps.netns_map;		     \

--- a/sample_tuner/Makefile
+++ b/sample_tuner/Makefile
@@ -87,8 +87,8 @@ $(TUNER_LIBS): $(BPF_SKELS) $(TUNER_OBJS)
 %.skel.h: %.bpf.o
 	$(QUIET_GEN)$(BPFTOOL) gen skeleton $< > $@
 
-$(BPF_OBJS): $(patsubst %.o,%.c,$(BPF_OBJS))
-	$(CLANG) -g -D__TARGET_ARCH_$(SRCARCH) -O2 -target bpf			\
+$(BPF_OBJS): $(patsubst %.o,%.c,$(BPF_OBJS)) ../include/bpftune/bpftune.bpf.h
+	$(CLANG) -g -D__TARGET_ARCH_$(SRCARCH) -O2 -target bpf		\
 		$(INCLUDES) -c $(patsubst %.o,%.c,$(@)) -o $(@);
 	$(CLANG) -g -D__TARGET_ARCH_$(SRCARCH) -DBPFTUNE_LEGACY -O2 -target bpf \
 		$(INCLUDES) -c $(patsubst %.o,%.c,$(@)) \

--- a/src/Makefile
+++ b/src/Makefile
@@ -163,16 +163,16 @@ $(OPATH)bpftune.o: $(OPATH)libbpftune.so
 %.skel.h: %.bpf.o
 	$(QUIET_GEN)$(BPFTOOL) gen skeleton $< > $@
 
-$(BPF_OBJS): $(patsubst %.o,%.c,$(BPF_OBJS))
+$(BPF_OBJS): $(patsubst %.o,%.c,$(BPF_OBJS)) ../include/bpftune/bpftune.bpf.h
 	$(CLANG) $(BPF_CFLAGS) -D__TARGET_ARCH_$(SRCARCH) -O2 -target bpf \
 		$(INCLUDES) -c $(patsubst %.o,%.c,$(@)) -o $(@)
 
-$(LEGACY_BPF_OBJS): $(patsubst %.legacy.o,%.c,$(LEGACY_BPF_OBJS))
+$(LEGACY_BPF_OBJS): $(patsubst %.legacy.o,%.c,$(LEGACY_BPF_OBJS)) ../include/bpftune/bpftune.bpf.h
 	$(CLANG) $(BPF_CFLAGS) -D__TARGET_ARCH_$(SRCARCH) -DBPFTUNE_LEGACY -O2 -target bpf \
 		$(INCLUDES) -c $(patsubst %.legacy.o,%.c,$(@)) \
 		-o $(@)
 
-$(NOBTF_BPF_OBJS): $(patsubst %.nobtf.o,%.c,$(NOBTF_BPF_OBJS))
+$(NOBTF_BPF_OBJS): $(patsubst %.nobtf.o,%.c,$(NOBTF_BPF_OBJS)) ../include/bpftune/bpftune.bpf.h
 	$(CLANG) $(BPF_CFLAGS) -D__TARGET_ARCH_$(SRCARCH) -DBPFTUNE_NOBTF -O2 -target bpf \
 		$(INCLUDES) -c $(patsubst %.nobtf.o,%.c,$(@)) \
 		-o $(@)

--- a/src/libbpftune.c
+++ b/src/libbpftune.c
@@ -1620,9 +1620,15 @@ int bpftuner_strategy_set(struct bpftuner *tuner,
 int bpftuner_strategies_add(struct bpftuner *tuner, struct bpftuner_strategy **strategies,
 			    struct bpftuner_strategy *default_strategy)
 {
+	struct bpftuner_strategy *strategy;
+	unsigned int strategy_id = 0;
+
 	if (!strategies || tuner->strategies)
 		return 0;
 	tuner->strategies = strategies;
+	/* assign ids to each strategy added; used in BPF context */
+	bpftuner_for_each_strategy(tuner, strategy)
+		strategy->id = strategy_id++;
 	if (default_strategy)
 		return bpftuner_strategy_set(tuner, default_strategy);
 	bpftuner_strategy_update(tuner);

--- a/test/strategy/Makefile
+++ b/test/strategy/Makefile
@@ -86,16 +86,16 @@ $(TUNER_LIBS): $(BPF_SKELS) $(TUNER_OBJS)
 
 $(TUNER_OBJS): $(BPF_SKELS) $(LEGACY_BPF_SKELS) $(NOBTF_BPF_SKELS)
 
-$(BPF_OBJS): $(patsubst %.o,%.c,$(BPF_OBJS))
+$(BPF_OBJS): $(patsubst %.o,%.c,$(BPF_OBJS)) ../../include/bpftune/bpftune.bpf.h
 	$(CLANG) $(BPF_CFLAGS) -D__TARGET_ARCH_$(SRCARCH) -O2 -target bpf \
 		$(INCLUDES) -c $(patsubst %.o,%.c,$(@)) -o $(@)
 
-$(LEGACY_BPF_OBJS): $(patsubst %.legacy.o,%.c,$(LEGACY_BPF_OBJS))
+$(LEGACY_BPF_OBJS): $(patsubst %.legacy.o,%.c,$(LEGACY_BPF_OBJS)) ../../include/bpftune/bpftune.bpf.h
 	$(CLANG) $(BPF_CFLAGS) -D__TARGET_ARCH_$(SRCARCH) -DBPFTUNE_LEGACY -O2 -target bpf \
 		$(INCLUDES) -c $(patsubst %.legacy.o,%.c,$(@)) \
 		-o $(@)
 
-$(NOBTF_BPF_OBJS): $(patsubst %.nobtf.o,%.c,$(NOBTF_BPF_OBJS))
+$(NOBTF_BPF_OBJS): $(patsubst %.nobtf.o,%.c,$(NOBTF_BPF_OBJS)) ../../include/bpftune/bpftune.bpf.h
 	$(CLANG) $(BPF_CFLAGS) -D__TARGET_ARCH_$(SRCARCH) -DBPFTUNE_NOBTF -O2 -target bpf \
 		$(INCLUDES) -c $(patsubst %.nobtf.o,%.c,$(@)) \
 		-o $(@)


### PR DESCRIPTION
tuners that share bpf programs across strategies may want to have different behaviours depending on which strategy is active; assign strategy ids when strategies are added to tuner and expose to bpf progs via strategy_id variable; it is set as part of bpftune_bpf_open().