### PR TITLE
update support test for aarch64 bpf trampoline support

### DIFF
--- a/test/support_test.sh
+++ b/test/support_test.sh
@@ -51,6 +51,14 @@ if [[ $MAJ_KVER -gt 4 ]]; then
 			fi	
 		fi
 		;;
+	6)
+		expected_netns="supports per-netns policy"
+		if [[ "$ARCH" == "x86_64" ]]; then
+			expected="bpftune works fully"
+		elif [[ $MIN_KVER -gt 4 ]]; then
+			expected="bpftune works fully"
+		fi
+		;;
 	*)
 		expected_netns="supports per-netns policy"
 		if [[ "$ARCH" == "x86_64" ]]; then


### PR DESCRIPTION
6.5 and later support bpf trampoline for aarch64; update test