### PR TITLE
tcp_conn_tuner: support summary output for non-debug case

### DIFF
--- a/include/bpftune/libbpftune.h
+++ b/include/bpftune/libbpftune.h
@@ -127,6 +127,11 @@ int bpftuner_tunable_update(struct bpftuner *tuner,
 			    int netns_fd,
 			    const char *fmt, ...);
 
+void bpftuner_tunable_stats_update(struct bpftuner *tuner,
+				   unsigned int tunable,
+				   unsigned int scenario, bool global_ns,
+				   unsigned long val);
+
 struct bpftuner *bpftune_tuner(unsigned int index);
 unsigned int bpftune_tuner_num(void);
 #define bpftune_for_each_tuner(tuner)					     \

--- a/src/libbpftune.map
+++ b/src/libbpftune.map
@@ -29,6 +29,7 @@ LIBBPFTUNE_0.1.1 {
 		bpftuner_num_tunables;
 		bpftuner_tunable_sysctl_write;
 		bpftuner_tunable_update;
+		bpftuner_tunable_stats_update;
 		bpftuner_fini;
 		bpftuner_bpf_fini;
 		bpftuner_bpf_set_autoload;

--- a/src/tcp_conn_tuner.h
+++ b/src/tcp_conn_tuner.h
@@ -24,8 +24,7 @@ enum tcp_cong_tunables {
 };
 
 enum tcp_cong_scenarios {
-	TCP_CONG_BBR,
-	TCP_CONG_HTCP,
+	TCP_CONG_SET
 };
 
 #define CONG_MAXNAME	16


### PR DESCRIPTION
is of the form

bpftune: Summary: scenario 'specify TCP congestion control algorithm' occurred 1 times for tunable 'TCP congestion control' in global ns. To optimize TCP performance, a TCP congestion control algorithm was chosen to mimimize round-trip time and maximize delivery rate.