### PR TITLE
tcp_buffer_tuner: make tcp_sndbuf_expand optional

### DIFF
--- a/src/tcp_buffer_tuner.c
+++ b/src/tcp_buffer_tuner.c
@@ -141,6 +141,8 @@ retry:
 
 int init(struct bpftuner *tuner)
 {
+	/* on some platforms, this function is inlined */
+	const char *optionals[] = { "tcp_sndbuf_expand", NULL };
 	int pagesize;
 	int err;
 
@@ -162,7 +164,7 @@ int init(struct bpftuner *tuner)
 			     ilog2(SK_MEM_QUANTUM));
 	bpftuner_bpf_var_set(tcp_buffer, tuner, nr_free_buffer_pages,
 			     nr_free_buffer_pages(true));
-	err = bpftuner_bpf_attach(tcp_buffer, tuner, NULL);
+	err = bpftuner_bpf_attach(tcp_buffer, tuner, optionals);
 	if (err)
 		return err;
 	return bpftuner_tunables_init(tuner, TCP_BUFFER_NUM_TUNABLES, descs,


### PR DESCRIPTION
in some cases this static function is inlined; make it optional to avoid failure to attach tuner as a whole.

Reported-by: sm99c (https://github.com/sm9cc)