### PR TITLE
fix optional support

### DIFF
--- a/include/bpftune/libbpftune.h
+++ b/include/bpftune/libbpftune.h
@@ -205,29 +205,23 @@ void bpftuner_tunables_fini(struct bpftuner *tuner);
 		}							     \
 	} while (0)
 
-#define _bpftuner_bpf_load(tuner_name, tuner, optionals) ({		     \
+#define bpftuner_bpf_load(tuner_name, tuner, optionals) ({		     \
 	int __err;							     \
 									     \
-	__err = __bpftuner_bpf_load(tuner, optionals);			     \
+	__err = __bpftuner_bpf_load(tuner, NULL);			     \
+	if (__err && optionals != NULL) {				     \
+		bpftuner_bpf_fini(tuner);				     \
+		__err = bpftuner_bpf_open(tuner_name, tuner);		     \
+		if (!__err)						     \
+			__err = __bpftuner_bpf_load(tuner, optionals);	     \
+	}								     \
 	if (__err)							     \
 		bpftuner_bpf_destroy(tuner_name, tuner);		     \
 	__err;								     \
 })
 
-#define bpftuner_bpf_load(tuner_name, tuner)				     \
-	_bpftuner_bpf_load(tuner_name, tuner, NULL)
-
-#define bpftuner_bpf_attach(tuner_name, tuner, optionals) ({		     \
+#define bpftuner_bpf_attach(tuner_name, tuner) ({		     	     \
 	int __err = __bpftuner_bpf_attach(tuner);			     \
-                                                                             \
-	if (__err && optionals != NULL) {				     \
-		bpftuner_bpf_fini(tuner);			 	     \
-		__err = bpftuner_bpf_open(tuner_name, tuner);	 	     \
-		if (!__err)						     \
-			__err = _bpftuner_bpf_load(tuner_name, tuner, optionals); \
-		if (!__err)						     \
-			__err = __bpftuner_bpf_attach(tuner);		     \
-	}								     \
 	__err;								     \
 })
 
@@ -235,9 +229,9 @@ void bpftuner_tunables_fini(struct bpftuner *tuner);
 	int __err = bpftuner_bpf_open(tuner_name, tuner);		     \
 									     \
 	if (!__err)							     \
-		__err = bpftuner_bpf_load(tuner_name, tuner);		     \
+		__err = bpftuner_bpf_load(tuner_name, tuner, optionals);		     \
 	if (!__err)							     \
-		bpftuner_bpf_attach(tuner_name, tuner, optionals);	     \
+		bpftuner_bpf_attach(tuner_name, tuner);			     \
 	__err;								     \
 })
 

--- a/sample_tuner/sample_tuner.bpf.c
+++ b/sample_tuner/sample_tuner.bpf.c
@@ -36,3 +36,8 @@ BPF_FENTRY(proc_dostring_coredump, struct ctl_table *table, int write,
 		      tuner_id, scenario_id, ret);
 	return 0;
 }
+
+BPF_FENTRY(this_function_does_not_exist, void *arg)
+{
+	return 0;
+}

--- a/sample_tuner/sample_tuner.c
+++ b/sample_tuner/sample_tuner.c
@@ -25,7 +25,10 @@
 
 int init(struct bpftuner *tuner)
 {
-	return bpftuner_bpf_init(sample, tuner, NULL);
+	const char *optionals[] = { "entry__this_function_does_not_exist",
+				    NULL };
+
+	return bpftuner_bpf_init(sample, tuner, optionals);
 }
 
 void fini(struct bpftuner *tuner)

--- a/src/libbpftune.c
+++ b/src/libbpftune.c
@@ -575,6 +575,8 @@ int __bpftuner_bpf_load(struct bpftuner *tuner, const char **optionals)
 		for (i = 0; optionals[i] != NULL; i++) {
 			struct bpf_program *prog;
 
+			bpftune_log(LOG_DEBUG, "looking for optional prog '%s'\n",
+				    optionals[i]);
 			prog = bpf_object__find_program_by_name(tuner->obj,
 								optionals[i]);
 			if (prog) {

--- a/src/net_buffer_tuner.c
+++ b/src/net_buffer_tuner.c
@@ -36,12 +36,12 @@ int init(struct bpftuner *tuner)
 	err = bpftuner_bpf_open(net_buffer, tuner);
 	if (err)
 		return err;
-	err = bpftuner_bpf_load(net_buffer, tuner);
+	err = bpftuner_bpf_load(net_buffer, tuner, NULL);
 	if (err)
 		return err;
 	bpftuner_bpf_var_set(net_buffer, tuner, flow_limit_cpu_bitmap,
 			     cpu_bitmap);
-	err = bpftuner_bpf_attach(net_buffer, tuner, NULL);
+	err = bpftuner_bpf_attach(net_buffer, tuner);
 	if (err)
 		return err;
 

--- a/src/netns_tuner.c
+++ b/src/netns_tuner.c
@@ -48,10 +48,10 @@ int init(struct bpftuner *tuner)
 	err = bpftuner_bpf_open(netns, tuner);
 	if (err)
 		return err;
-	err = bpftuner_bpf_load(netns, tuner);
+	err = bpftuner_bpf_load(netns, tuner, optionals);
 	if (err)
 		return err;
-	err = bpftuner_bpf_attach(netns, tuner, optionals);
+	err = bpftuner_bpf_attach(netns, tuner);
 	if (err)
 		return err;
 

--- a/src/tcp_buffer_tuner.c
+++ b/src/tcp_buffer_tuner.c
@@ -142,14 +142,14 @@ retry:
 int init(struct bpftuner *tuner)
 {
 	/* on some platforms, this function is inlined */
-	const char *optionals[] = { "tcp_sndbuf_expand", NULL };
+	const char *optionals[] = { "entry__tcp_sndbuf_expand", NULL };
 	int pagesize;
 	int err;
 
 	err = bpftuner_bpf_open(tcp_buffer, tuner);
 	if (err)
 		return err;
-	err = bpftuner_bpf_load(tcp_buffer, tuner);
+	err = bpftuner_bpf_load(tcp_buffer, tuner, optionals);
 	if (err)
 		return err;
 
@@ -164,7 +164,7 @@ int init(struct bpftuner *tuner)
 			     ilog2(SK_MEM_QUANTUM));
 	bpftuner_bpf_var_set(tcp_buffer, tuner, nr_free_buffer_pages,
 			     nr_free_buffer_pages(true));
-	err = bpftuner_bpf_attach(tcp_buffer, tuner, optionals);
+	err = bpftuner_bpf_attach(tcp_buffer, tuner);
 	if (err)
 		return err;
 	return bpftuner_tunables_init(tuner, TCP_BUFFER_NUM_TUNABLES, descs,


### PR DESCRIPTION
we can specify optional bpf progs at load time; simplify the code that does this and add logging; also add testing for this feature via the sample tuner.