### PR TITLE
change netns logging to debug-only, make fib6_age optional

### DIFF
--- a/src/netns_tuner.c
+++ b/src/netns_tuner.c
@@ -100,9 +100,9 @@ void event_handler(__attribute__((unused))struct bpftuner *tuner,
 	default:
 		return;
 	}
-	bpftuner_tunable_update(tuner, NETNS, event->scenario_id, netns_fd,
-				"netns %s (cookie %ld)\n",
-				event->scenario_id == NETNS_SCENARIO_CREATE ?
-				"created" : "destroyed",
-				event->netns_cookie);
+	/* use debug logging as these events are very frequent. */
+	bpftune_log(LOG_DEBUG, "netns %s (cookie %ld)\n",
+		    event->scenario_id == NETNS_SCENARIO_CREATE ?
+			"created" : "destroyed",
+			event->netns_cookie);
 }

--- a/src/route_table_tuner.c
+++ b/src/route_table_tuner.c
@@ -39,7 +39,9 @@ static struct bpftunable_scenario scenarios[] = {
 
 int init(struct bpftuner *tuner)
 {
-	int err = bpftuner_bpf_init(route_table, tuner, NULL);
+	const char *optionals[] = { "entry__fib6_age", NULL };
+
+	int err = bpftuner_bpf_init(route_table, tuner, optionals);
 
 	if (err)
 		return err;


### PR DESCRIPTION
in former case, logs were too noisy as netns creation/destruction is very frequent, in latter case fib6_age is inlined/missing on upstream kernels.