### PR TITLE
tcp_buffer_tuner: fix load failure for 6.9+

### DIFF
--- a/src/tcp_buffer_tuner.bpf.c
+++ b/src/tcp_buffer_tuner.bpf.c
@@ -242,8 +242,11 @@ BPF_FENTRY(tcp_rcv_space_adjust, struct sock *sk)
 		return 0;
 
 #ifndef BPFTUNE_LEGACY
-	/* CO-RE does not support bitfields... */
-	sk_userlocks = sk->sk_userlocks;
+	/* sk_userlocks is a bitfield prior to 6.9 */
+	if (LINUX_KERNEL_VERSION < KERNEL_VERSION(6, 9, 0)) {
+		/* CO-RE does not support bitfields... */
+		sk_userlocks = sk->sk_userlocks;
+	}
 #endif
 	if ((sk_userlocks & SOCK_RCVBUF_LOCK) || near_memory_pressure ||
 	    near_memory_exhaustion)


### PR DESCRIPTION
TCP buffer tuner was failing to load on 6.9 and later.

CO-RE relocation for sk_userlocks in struct sock was the cause; the problem is sk_userlocks changes from a bitfield to a plain u8 and the vmlinux.h that was generated had the old representation. We can use a Linux version check to guard check of sk_userlocks.

Reported-by: HippieMitch <https://github.com/HippieMitch>