### PR TITLE
Add support of gcc BPF backend

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -22,6 +22,7 @@ SRCARCH := $(shell uname -m | sed -e s/i.86/x86/ -e s/x86_64/x86/ \
 				  -e s/aarch64.*/arm64/ )
 
 CLANG ?= clang
+GCC_BPF ?=
 LLC ?= llc
 LLVM_STRIP ?= llvm-strip
 BPFTOOL ?= bpftool
@@ -29,7 +30,6 @@ BPF_INCLUDE := /usr/include
 BPF_CFLAGS := -g -fno-stack-protector -Wall
 NL_INCLUDE := /usr/include/libnl3
 INCLUDES := -I../include -I$(BPF_INCLUDE) -I$(NL_INCLUDE) -I../include/uapi
-
 INSTALL ?= install
 
 DESTDIR ?= /
@@ -104,11 +104,15 @@ NOBTF_BPF_SKELS = $(patsubst %.skel.h,%.skel.nobtf.h,$(BPF_SKELS))
 
 .PHONY: clean
 
+ifeq ($(GCC_BPF),)
 all: analyze $(OPATH) $(OPATH)bpftune $(TUNER_LIBS)
+else
+all: $(OPATH) $(OPATH)bpftune $(TUNER_LIBS)
+endif
 
 $(OPATH):
 	mkdir $(OPATH)
-	
+
 analyze: $(BPF_SKELS) $(LEGACY_BPF_SKELS) $(NOBTF_BPF_SKELS)
 	$(CLANG) --analyze $(INCLUDES) libbpftune.c bpftune.c $(TUNER_SRCS)
 clean:
@@ -163,6 +167,8 @@ $(OPATH)bpftune.o: $(OPATH)libbpftune.so
 %.skel.h: %.bpf.o
 	$(QUIET_GEN)$(BPFTOOL) gen skeleton $< > $@
 
+# check if GCC_BPF flag is set, otherwise use CLANG
+ifeq ($(GCC_BPF),)
 $(BPF_OBJS): $(patsubst %.o,%.c,$(BPF_OBJS)) ../include/bpftune/bpftune.bpf.h
 	$(CLANG) $(BPF_CFLAGS) -D__TARGET_ARCH_$(SRCARCH) -O2 -target bpf \
 		$(INCLUDES) -c $(patsubst %.o,%.c,$(@)) -o $(@)
@@ -176,6 +182,26 @@ $(NOBTF_BPF_OBJS): $(patsubst %.nobtf.o,%.c,$(NOBTF_BPF_OBJS)) ../include/bpftun
 	$(CLANG) $(BPF_CFLAGS) -D__TARGET_ARCH_$(SRCARCH) -DBPFTUNE_NOBTF -O2 -target bpf \
 		$(INCLUDES) -c $(patsubst %.nobtf.o,%.c,$(@)) \
 		-o $(@)
+else
+GCC_BPF_FLAGS := -g -O2 \
+	$(BPF_CFLAGS) -D__TARGET_ARCH_$(SRCARCH) \
+	-gbtf -mcpu=v3 -Wno-error=attributes \
+	-Wno-error=address-of-packed-member \
+	-Wno-compare-distinct-pointer-types \
+	$(INCLUDES)
+
+$(BPF_OBJS): $(patsubst %.o,%.c,$(BPF_OBJS)) ../include/bpftune/bpftune.bpf.h
+	$(GCC_BPF) $(GCC_BPF_FLAGS) -c $(patsubst %.o,%.c,$(@)) \
+		-o $(@)
+
+$(LEGACY_BPF_OBJS): $(patsubst %.legacy.o,%.c,$(LEGACY_BPF_OBJS)) ../include/bpftune/bpftune.bpf.h
+	$(GCC_BPF) $(GCC_BPF_FLAGS) -DBPFTUNE_LEGACY -c $(patsubst %.legacy.o,%.c,$(@)) \
+		-o $(@)
+
+$(NOBTF_BPF_OBJS): $(patsubst %.nobtf.o,%.c,$(NOBTF_BPF_OBJS)) ../include/bpftune/bpftune.bpf.h
+	$(GCC_BPF) $(GCC_BPF_FLAGS) -DBPFTUNE_NOBTF -c $(patsubst %.nobtf.o,%.c,$(@)) \
+		-o $(@)
+endif
 
 $(BPF_SKELS): $(BPF_OBJS)
 	$(BPFTOOL) gen skeleton $(subst .skel.h,.bpf.o,$@) > $@
@@ -185,4 +211,3 @@ $(LEGACY_BPF_SKELS): $(LEGACY_BPF_OBJS)
 
 $(NOBTF_BPF_SKELS): $(NOBTF_BPF_OBJS)
 	$(BPFTOOL) gen skeleton $(subst .skel.nobtf.h,.bpf.nobtf.o,$@) > $(subst .skel.h,.skel.nobtf.h,$@)
-

--- a/test/strategy/Makefile
+++ b/test/strategy/Makefile
@@ -25,10 +25,11 @@ CLANG ?= clang
 LLC ?= llc
 LLVM_STRIP ?= llvm-strip
 BPFTOOL ?= bpftool
-BPF_INCLUDE := ../../include
+GCC_BPF ?=
+BPF_INCLUDE := /usr/include
 BPF_CFLAGS := -g -fno-stack-protector -Wall
 NL_INCLUDE := /usr/include/libnl3
-INCLUDES := -I$(BPF_INCLUDE) -I$(NL_INCLUDE) -I/usr/include/uapi
+INCLUDES := -I../../include -I$(BPF_INCLUDE) -I$(NL_INCLUDE) -I/usr/include/uapi
 
 INSTALL ?= install
 
@@ -74,7 +75,7 @@ NOBTF_BPF_SKELS = $(patsubst %.skel.h,%.skel.nobtf.h,$(BPF_SKELS))
 .PHONY: clean
 
 all: $(TUNER_LIBS)
-	
+
 clean:
 	$(Q)$(RM) *.o *.d *.so*
 	$(Q)$(RM) *.skel*.h
@@ -86,6 +87,9 @@ $(TUNER_LIBS): $(BPF_SKELS) $(TUNER_OBJS)
 
 $(TUNER_OBJS): $(BPF_SKELS) $(LEGACY_BPF_SKELS) $(NOBTF_BPF_SKELS)
 
+
+# check if GCC_BPF flag is set, otherwise use CLANG
+ifeq ($(GCC_BPF),)
 $(BPF_OBJS): $(patsubst %.o,%.c,$(BPF_OBJS)) ../../include/bpftune/bpftune.bpf.h
 	$(CLANG) $(BPF_CFLAGS) -D__TARGET_ARCH_$(SRCARCH) -O2 -target bpf \
 		$(INCLUDES) -c $(patsubst %.o,%.c,$(@)) -o $(@)
@@ -100,6 +104,28 @@ $(NOBTF_BPF_OBJS): $(patsubst %.nobtf.o,%.c,$(NOBTF_BPF_OBJS)) ../../include/bpf
 		$(INCLUDES) -c $(patsubst %.nobtf.o,%.c,$(@)) \
 		-o $(@)
 
+else
+GCC_BPF_FLAGS := -g -O2 \
+	$(BPF_CFLAGS) -D__TARGET_ARCH_$(SRCARCH) \
+	-gbtf -mcpu=v3 -Wno-error=attributes \
+	-Wno-error=address-of-packed-member \
+	-Wno-compare-distinct-pointer-types \
+	$(INCLUDES)
+
+$(BPF_OBJS): $(patsubst %.o,%.c,$(BPF_OBJS)) ../../include/bpftune/bpftune.bpf.h
+	$(GCC_BPF) $(GCC_BPF_FLAGS) -c $(patsubst %.o,%.c,$(@)) \
+		-o $(@)
+
+$(LEGACY_BPF_OBJS): $(patsubst %.legacy.o,%.c,$(LEGACY_BPF_OBJS)) ../../include/bpftune/bpftune.bpf.h
+	$(GCC_BPF) $(GCC_BPF_FLAGS) -DBPFTUNE_LEGACY -c $(patsubst %.legacy.o,%.c,$(@)) \
+		-o $(@)
+
+$(NOBTF_BPF_OBJS): $(patsubst %.nobtf.o,%.c,$(NOBTF_BPF_OBJS)) ../../include/bpftune/bpftune.bpf.h
+	$(GCC_BPF) $(GCC_BPF_FLAGS) -DBPFTUNE_NOBTF -c $(patsubst %.nobtf.o,%.c,$(@)) \
+		-o $(@)
+
+endif
+
 $(BPF_SKELS): $(BPF_OBJS)
 	$(BPFTOOL) gen skeleton $(subst .skel.h,.bpf.o,$@) > $@
 
@@ -108,4 +134,3 @@ $(LEGACY_BPF_SKELS): $(LEGACY_BPF_OBJS)
 
 $(NOBTF_BPF_SKELS): $(NOBTF_BPF_OBJS)
 	$(BPFTOOL) gen skeleton $(subst .skel.nobtf.h,.bpf.nobtf.o,$@) > $(subst .skel.h,.skel.nobtf.h,$@)
-


### PR DESCRIPTION
Hey, Alan. 

Thanks for all the work on bpftune (and your informative talks on BTF :smile: ).

I wanted to begin the process of porting `bpftune` to support the BPF backend for gcc.

I started with the Makefile(s). 

On my fork, you can:
```
GCC_BPF=bpf-gcc make && sudo make install
```
It compiles successfully (and throws warnings due to ignoring unkown clang #pragmas).

Then you can run `bpftune` in legacy mode:
``` 
$ sudo bpftune -S     
bpftune: bpftune works in legacy mode
bpftune: bpftune supports per-netns policy (via netns cookie)
```

Below are the specifications for the machine I am testing on. 
I use upstream Debian for my work as much as possible:
```
$ bpf-gcc --version 
bpf-gcc (14.1.0-1+2) 14.1.0
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ bpftool version                       
bpftool v7.4.0
using libbpf v1.4
features:

$ ll /usr/lib64/ | sudo grep libbpf.so                       
lrwxrwxrwx 1 root root   11 Jun  6 13:33 libbpf.so -> libbpf.so.1
lrwxrwxrwx 1 root root   15 Jun  6 13:33 libbpf.so.1 -> libbpf.so.1.4.3
-rwxr-xr-x 1 root root 1.6M Jun  6 13:33 libbpf.so.1.4.3

$ uname -m && lsb_release -d && uname -r
x86_64
No LSB modules are available.
Description:    Debian GNU/Linux trixie/sid
6.7.12-amd64
```

I was wondering how I could help `bpftune` support the gcc backend for BPF and get `bpftune` to work "fully" out of the box with it.