### PR TITLE
better handle nonstandard library install paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,15 @@ $ make pkg
 
 target, which will make a bpftune RPM.  See ./buildrpm/bpftune.spec
 
+We can also build with non-standard libdir for distros which do not
+use /usr/lib64 like CachyOS; in this case to install to /usr/lib
+instead
+
+```
+$ make libdir=lib
+$ sudo make install libdir=lib
+```
+
 To build the following packages are needed (names may vary by distro);
 
 - libbpf, libbpf-devel >= 0.6

--- a/include/bpftune/libbpftune.h
+++ b/include/bpftune/libbpftune.h
@@ -51,9 +51,9 @@
 #define LIB_DIR				"lib64"
 #endif
 /* default /usr/lib64/bpftune */
-#define BPFTUNER_LIB_DIR		BPFTUNER_PREFIX_DIR LIB_DIR "/bpftune/"
+#define BPFTUNER_LIB_DIR		BPFTUNER_PREFIX_DIR "/" LIB_DIR "/bpftune/"
 /* default /usr/local/lib64/bpftune */
-#define BPFTUNER_LOCAL_LIB_DIR		BPFTUNER_PREFIX_DIR "local/" LIB_DIR "/bpftune/"
+#define BPFTUNER_LOCAL_LIB_DIR		BPFTUNER_PREFIX_DIR "/local/" LIB_DIR "/bpftune/"
 #define BPFTUNER_LIB_SUFFIX		"_tuner.so"
 
 #define BPFTUNE_PROC_SYS		"/proc/sys/"

--- a/include/bpftune/libbpftune.h
+++ b/include/bpftune/libbpftune.h
@@ -44,8 +44,16 @@
 
 #define BPFTUNE_RUN_DIR			"/var/run/bpftune"
 #define BPFTUNER_CGROUP_DIR		BPFTUNE_RUN_DIR "/cgroupv2"
-#define BPFTUNER_LIB_DIR		"/usr/lib64/bpftune/"
-#define BPFTUNER_LOCAL_LIB_DIR		"/usr/local/lib64/bpftune/"
+#ifndef BPFTUNER_PREFIX_DIR
+#define BPFTUNER_PREFIX_DIR		"/usr"
+#endif
+#ifndef LIB_DIR
+#define LIB_DIR				"lib64"
+#endif
+/* default /usr/lib64/bpftune */
+#define BPFTUNER_LIB_DIR		BPFTUNER_PREFIX_DIR LIB_DIR "/bpftune/"
+/* default /usr/local/lib64/bpftune */
+#define BPFTUNER_LOCAL_LIB_DIR		BPFTUNER_PREFIX_DIR "local/" LIB_DIR "/bpftune/"
 #define BPFTUNER_LIB_SUFFIX		"_tuner.so"
 
 #define BPFTUNE_PROC_SYS		"/proc/sys/"

--- a/src/Makefile
+++ b/src/Makefile
@@ -34,6 +34,7 @@ INSTALL ?= install
 
 DESTDIR ?= /
 prefix ?= /usr
+libdir ?= lib64
 installprefix = $(DESTDIR)/$(prefix)
 
 INSTALLPATH = $(installprefix)
@@ -57,11 +58,14 @@ VERSION_SCRIPT  := libbpftune.map
 
 CFLAGS = -fPIC -Wall -Wextra -march=native -g -I../include -std=c99
 
-CFLAGS += -DBPFTUNE_VERSION='"$(BPFTUNE_VERSION)"' $(INCLUDES)
+CFLAGS += -DBPFTUNE_VERSION='"$(BPFTUNE_VERSION)"' \
+	  -DBPFTUNER_PREFIX_DIR='"$(prefix)"' \
+	  -DLIB_DIR='"$(libdir)"' \
+	  $(INCLUDES)
 
 LDLIBS = -lbpf -ldl -lm -lrt -lcap -lnl-3 -lpthread -lnl-route-3
 
-LDFLAGS += -L. -L/usr/local/lib64
+LDFLAGS += -L. -L$(prefix)/$(libdir)
 
 # Try to detect best kernel BTF source
 KERNEL_REL := $(shell uname -r)
@@ -128,15 +132,15 @@ distclean: clean
 install: $(OPATH)libbpftune.so $(OPATH)bpftune bpftune.service
 	$(INSTALL) -m 0755 -d $(INSTALLPATH)/sbin
 	$(INSTALL) $(OPATH)bpftune $(INSTALLPATH)/sbin/bpftune
-	$(INSTALL) -m 0755 -d $(INSTALLPATH)/lib64
-	$(INSTALL) $(OPATH)libbpftune.so* $(INSTALLPATH)/lib64
+	$(INSTALL) -m 0755 -d $(INSTALLPATH)/$(libdir)
+	$(INSTALL) $(OPATH)libbpftune.so* $(INSTALLPATH)/$(libdir)
 	$(INSTALL) -m 0755 -d $(installprefix)/lib/systemd/system
 	$(INSTALL) -m 644 bpftune.service $(installprefix)/lib/systemd/system
-	$(INSTALL) -m 0755 -d $(INSTALLPATH)/lib64/bpftune
-	$(INSTALL) $(TUNER_LIBS) $(INSTALLPATH)/lib64/bpftune
+	$(INSTALL) -m 0755 -d $(INSTALLPATH)/$(libdir)/bpftune
+	$(INSTALL) $(TUNER_LIBS) $(INSTALLPATH)/$(libdir)/bpftune
 	$(INSTALL) -m 0755 -d $(CONF)
 	$(INSTALL) -m 0755 -d $(CONFPATH)
-	echo $(prefix)/lib64 > $(CONFPATH)/libbpftune.conf
+	echo $(prefix)/$(libdir) > $(CONFPATH)/libbpftune.conf
 	if [ $(DESTDIR) =  / ]; then ldconfig; fi
 
 $(OPATH)bpftune: bpftune.c $(OPATH)bpftune.o $(OPATH)libbpftune.so


### PR DESCRIPTION
support install to /usr/lib instead of default /usr/lib64 through libdir=lib specification for make and make install targets