### PR TITLE
src/Makefile: remove -march=native, allow override of SRCARCH

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -17,7 +17,7 @@
 # Boston, MA 021110-1307, USA.
 #
 
-SRCARCH := $(shell uname -m | sed -e s/i.86/x86/ -e s/x86_64/x86/ \
+SRCARCH ?= $(shell uname -m | sed -e s/i.86/x86/ -e s/x86_64/x86/ \
 				  -e /arm64/!s/arm.*/arm/ -e s/sa110/arm/ \
 				  -e s/aarch64.*/arm64/ )
 
@@ -56,7 +56,7 @@ endif
 VERSION = 0.1.3
 VERSION_SCRIPT  := libbpftune.map
 
-CFLAGS = -fPIC -Wall -Wextra -march=native -g -I../include -std=c99
+CFLAGS = -fPIC -Wall -Wextra -g -I../include -std=c99
 
 CFLAGS += -DBPFTUNE_VERSION='"$(BPFTUNE_VERSION)"' \
 	  -DBPFTUNER_PREFIX_DIR='"$(prefix)"' \


### PR DESCRIPTION
to work towards cross-compile support, allow specification of SRCARCH which is passed into BPF compilation targets via
-D__TARGET_ARCH_$(SRCARCH). -march=native is not needed.