### PR TITLE
libbpftune: only send events to active tuners

### DIFF
--- a/src/libbpftune.c
+++ b/src/libbpftune.c
@@ -783,7 +783,9 @@ static int bpftune_ringbuf_event_read(void *ctx, void *data, size_t size)
 		    event->netns_cookie,
 		    event->netns_cookie && event->netns_cookie != global_netns_cookie ?
 		    "non-global netns" : "global netns");
-	tuner->event_handler(tuner, event, ctx);
+	/* only send events to active tuners */
+	if (tuner->state == BPFTUNE_ACTIVE)
+		tuner->event_handler(tuner, event, ctx);
 
 	return 0;
 }


### PR DESCRIPTION
Roger reported a segmentation fault in tcp_buffer_tuner. Examining the state of the tuner we were handling an event when in manual (i.e. off) state.  The event handler for a tuner should only be called if the tuner is active.

Reported by: Roger Knobbe (https://github.com/rknobbe)
Signed-off-by: Alan Maguire <alan.maguire@oracle.com>