### PR TITLE
Nsfixes2

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -166,7 +166,7 @@ $(TUNER_LIBS): $(OPATH)libbpftune.so $(TUNER_OBJS)
 	$(CC) $(CFLAGS) -shared -o $(@) $(patsubst $(OPATH)%.so,%.c,$(@)) \
 		$(LDLIBS) -lbpftune $(LDFLAGS)
 
-$(OPATH)libbpftune.o: probe.skel.h probe.skel.legacy.h probe.skel.nobtf.h
+$(OPATH)libbpftune.o: probe.skel.h probe.skel.legacy.h probe.skel.nobtf.h libbpftune.c
 	$(QUIET_CC)$(CC) $(CFLAGS) -c libbpftune.c -o $@
 
 $(OPATH)bpftune.o: $(OPATH)libbpftune.so


### PR DESCRIPTION
fixes around non-global network namespaces and sysctl-based disable when external entity changes a sysctl we manage. prior to these fixes we were disabling non-global ns when the global ns was switched off; these changes ensure non-global ns can still work when global has been disabled. also add the name of the process that triggered the disable for better diagnosis.