### PR TITLE
test: add podman tests

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -25,6 +25,7 @@ TUNER_TESTS =	support_test log_test service_test inotify_test cap_test \
 		strategy_test strategy_legacy_test \
 		rollback_test rollback_legacy_test \
 		many_netns_test many_netns_legacy_test \
+		podman_globalonly_test podman_globalonly_legacy_test \
 		sysctl_test sysctl_legacy_test sysctl_netns_test \
 		netns_test netns_legacy_test \
 		backlog_test backlog_legacy_test \

--- a/test/netns_legacy_test.sh
+++ b/test/netns_legacy_test.sh
@@ -23,6 +23,7 @@
 
 . ./test_lib.sh
 
+check_podman
 
 SLEEPTIME=2
 

--- a/test/netns_test.sh
+++ b/test/netns_test.sh
@@ -29,6 +29,7 @@ PROXYT_SERVICE=""
 
 . ./test_lib.sh
 
+check_podman
 
 SLEEPTIME=2
 

--- a/test/podman_globalonly_legacy_test.sh
+++ b/test/podman_globalonly_legacy_test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/bash
+#
+# SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note
+#
+# Copyright (c) 2023, Oracle and/or its affiliates.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License v2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public
+# License along with this program; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 021110-1307, USA.
+#
+
+. ./test_lib.sh
+
+check_podman
+
+SLEEPTIME=20
+TIMEOUT=30
+
+for FAMILY in ipv4 ; do
+
+   SYSCTL_NAME="net.ipv4.ipfrag_high_thresh"
+
+   test_start "$0|podman sysctl test (non-namespaced $SYSCTL_NAME)"
+
+   if [[ -z $PODMAN ]]; then
+	echo "podman not supported, skipping"
+	test_pass
+	continue
+   fi
+   if [[ ${BPFTUNE_NETNS} -eq 0 ]]; then
+	echo "bpftune does not support per-netns policy, skipping..."
+	test_pass
+	continue
+   fi
+   test_setup true
+
+   frag_pre=$(sysctl -qn $SYSCTL_NAME)
+   sysctl -w ${SYSCTL_NAME}=8192
+   container=
+   for MODE in baseline test ; do
+
+	echo "Running ${MODE}..."
+	test_run_cmd_local "$PODMAN_CMD sleep $SLEEPTIME &" true
+	if [[ $MODE != "baseline" ]]; then
+		test_run_cmd_local "$BPFTUNE -sL &" true
+	fi
+	sleep $SETUPTIME
+	container=$(ip netns show | awk '/^netns/ { print $1 }')
+	container_ip=$(ip netns exec $container ip addr show dev eth0 | awk '/inet / { split($2, a, "/"); print a[1] }')
+	ip netns exec $container  ethtool --offload eth0 rx off tx off gso off gro off lro off tso off
+	set +e
+	ping -v -c 20 -M want -s 8192 $container_ip
+	set -e
+   done
+   frag_post=$(sysctl -qn $SYSCTL_NAME)
+   sysctl -w ${SYSCTL_NAME}=${frag_pre}
+   echo "$SYSCTL_NAME pre-test 8192, after $frag_post"
+   if [[ "$frag_post" -gt "8192" ]]; then
+	   test_pass
+   fi
+
+   test_cleanup
+done
+
+test_exit

--- a/test/podman_globalonly_test.sh
+++ b/test/podman_globalonly_test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/bash
+#
+# SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note
+#
+# Copyright (c) 2023, Oracle and/or its affiliates.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License v2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public
+# License along with this program; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 021110-1307, USA.
+#
+
+. ./test_lib.sh
+
+check_podman
+
+SLEEPTIME=20
+TIMEOUT=30
+
+for FAMILY in ipv4 ; do
+
+   SYSCTL_NAME="net.ipv4.ipfrag_high_thresh"
+
+   test_start "$0|podman sysctl test (non-namespaced $SYSCTL_NAME)"
+
+   if [[ -z $PODMAN ]]; then
+	echo "podman not supported, skipping"
+	test_pass
+	continue
+   fi
+   if [[ ${BPFTUNE_NETNS} -eq 0 ]]; then
+	echo "bpftune does not support per-netns policy, skipping..."
+	test_pass
+	continue
+   fi
+   test_setup true
+
+   frag_pre=$(sysctl -qn $SYSCTL_NAME)
+   sysctl -w ${SYSCTL_NAME}=8192
+   container=
+   for MODE in baseline test ; do
+
+	echo "Running ${MODE}..."
+	test_run_cmd_local "$PODMAN_CMD sleep $SLEEPTIME &" true
+	if [[ $MODE != "baseline" ]]; then
+		test_run_cmd_local "$BPFTUNE -s &" true
+	fi
+	sleep $SETUPTIME
+	container=$(ip netns show | awk '/^netns/ { print $1 }')
+	container_ip=$(ip netns exec $container ip addr show dev eth0 | awk '/inet / { split($2, a, "/"); print a[1] }')
+	ip netns exec $container  ethtool --offload eth0 rx off tx off gso off gro off lro off tso off
+	set +e
+	ping -v -c 20 -M want -s 8192 $container_ip
+	set -e
+   done
+   frag_post=$(sysctl -qn $SYSCTL_NAME)
+   sysctl -w ${SYSCTL_NAME}=${frag_pre}
+   echo "$SYSCTL_NAME pre-test 8192, after $frag_post"
+   if [[ "$frag_post" -gt "8192" ]]; then
+	   test_pass
+   fi
+
+   test_cleanup
+done
+
+test_exit

--- a/test/test_lib.sh
+++ b/test/test_lib.sh
@@ -121,15 +121,21 @@ export PODMAN=$(which podman 2>/dev/null)
 export PODMAN_SEARCH="$PODMAN search oraclelinux"
 export PROXYT_SERVICE=${PROXYT_SERVICE:-"proxyt"}
 
-# only use podman if it can access images
-if [[ -n $PODMAN ]]; then
-	set +e
-	timeout 5 $PODMAN_SEARCH > /dev/null 2>&1
-	if [[ $? -ne 0 ]]; then
-		PODMAN=""
+check_podman()
+{
+	# only use podman if it can access images
+	if [[ -n $PODMAN ]]; then
+		set +e
+		if [[ -n "$PROXYT_SERVICE" ]]; then
+			service proxyt start
+		fi
+		timeout $TIMEOUT $PODMAN_SEARCH > /dev/null 2>&1
+		if [[ $? -ne 0 ]]; then
+			PODMAN=""
+		fi
+		set -e
 	fi
-	set -e
-fi
+}
 
 export PODMAN_CONTAINER=${PODMAN_CONTAINER:-"container-registry.oracle.com/os/oraclelinux:8-slim"}
 export PODMAN_CMD="${PODMAN} run --rm $PODMAN_CONTAINER"


### PR DESCRIPTION
first tests verify that changes observed in a non-global podman netns for a global-only tunable trigger global tunable changes; in this case fragmentation memory limits trigger increase in fragmentation high threshold.