### PR TITLE
libbpftune: fix bpftune_netns_info() checks when searching for netns …

### DIFF
--- a/src/libbpftune.c
+++ b/src/libbpftune.c
@@ -1487,7 +1487,8 @@ static int bpftune_netns_find(unsigned long cookie)
 		mntfd = open(ent->mnt_dir, O_RDONLY);
 		if (mntfd < 0)
 			continue;
-		if (bpftune_netns_info(0, &mntfd, &netns_cookie)) {
+		if (bpftune_netns_info(0, &mntfd, &netns_cookie) ||
+		    (cookie && netns_cookie != cookie)) {
 			close(mntfd);
 			continue;
 		}


### PR DESCRIPTION
…cookie

netns cookie check does not verify cookie is the one we are looking for; this means we match first cookie we find and misapply changes when multiple netns are in place.

Reported-by: Roger Knobbe <https://github.com/rknobbe>