### PR TITLE
CI workflow for Debian packaging

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 jobs:
-  build-debs:
+  build-debian-testing:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -14,4 +14,14 @@ jobs:
           DEB_BUILD_OPTIONS: noautodbgsym
         with:
           buildpackage-opts: --build=binary --no-sign
+          docker-image: debian:testing-slim
 
+  build-debian-stable:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jtdor/build-deb-action@v1
+        env:
+          DEB_BUILD_OPTIONS: noautodbgsym
+        with:
+          buildpackage-opts: --build=binary --no-sign

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -1,0 +1,17 @@
+name: Debian Packaging CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-debs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jtdor/build-deb-action@v1
+        env:
+          DEB_BUILD_OPTIONS: noautodbgsym
+        with:
+          buildpackage-opts: --build=binary --no-sign
+


### PR DESCRIPTION
This PR adds github workflows to build Debian package.

Artifacts are not published yet, please decide if/how you want to handle this - they are stored in debian/artifacts in the workspace directory.