### PR TITLE
Always set `installprefix`

### DIFF
--- a/include/Makefile
+++ b/include/Makefile
@@ -21,7 +21,7 @@ INSTALLFILES = $(wildcard bpftune/*.h)
 
 DESTDIR ?=
 prefix ?= /usr
-installprefix ?= $(DESTDIR)/$(prefix)
+installprefix = $(DESTDIR)/$(prefix)
 
 INSTALLPATH = $(installprefix)/include
 


### PR DESCRIPTION
This aligns how `include/Makefile` and `src/Makefile` treat this, and fixes `make pkg` to not fail due to missing include files that ended up in a different directory.

Error I see on main on Fedora 41 with `make pkg`:
```
...
RPM build errors:
    File not found: /home/andreas/rpmbuild/BUILD/bpftune-0.1-build/BUILDROOT/usr/include/bpftune
make: *** [Makefile:52: pkg] Error 1
```

Looking at the install output:
```
+ /usr/bin/make install DESTDIR=/home/andreas/rpmbuild/BUILD/bpftune-0.1-build/BUILDROOT 'INSTALL=/usr/bin/install -p'
make[1]: Entering directory '/home/andreas/rpmbuild/BUILD/bpftune-0.1-build/bpftune-0.1'
cd src; make install
make[2]: Entering directory '/home/andreas/rpmbuild/BUILD/bpftune-0.1-build/bpftune-0.1/src'
fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
/usr/bin/install -p -m 0755 -d /home/andreas/rpmbuild/BUILD/bpftune-0.1-build/BUILDROOT//usr/sbin
/usr/bin/install -p bpftune /home/andreas/rpmbuild/BUILD/bpftune-0.1-build/BUILDROOT//usr/sbin/bpftune
/usr/bin/install -p -m 0755 -d /home/andreas/rpmbuild/BUILD/bpftune-0.1-build/BUILDROOT//usr/lib64
/usr/bin/install -p libbpftune.so* /home/andreas/rpmbuild/BUILD/bpftune-0.1-build/BUILDROOT//usr/lib64
/usr/bin/install -p -m 0755 -d /home/andreas/rpmbuild/BUILD/bpftune-0.1-build/BUILDROOT//usr/lib/systemd/system
/usr/bin/install -p -m 644 bpftune.service /home/andreas/rpmbuild/BUILD/bpftune-0.1-build/BUILDROOT//usr/lib/systemd/system
/usr/bin/install -p -m 0755 -d /home/andreas/rpmbuild/BUILD/bpftune-0.1-build/BUILDROOT//usr/lib64/bpftune
/usr/bin/install -p tcp_buffer_tuner.so route_table_tuner.so neigh_table_tuner.so sysctl_tuner.so tcp_conn_tuner.so netns_tuner.so net_buffer_tuner.so ip_frag_tuner.so /home/andreas/rpmbuild/BUILD/bpftune-0.1-build/BUILDROOT//usr/lib64/bpftune
/usr/bin/install -p -m 0755 -d /home/andreas/rpmbuild/BUILD/bpftune-0.1-build/BUILDROOT//etc
/usr/bin/install -p -m 0755 -d /home/andreas/rpmbuild/BUILD/bpftune-0.1-build/BUILDROOT//etc/ld.so.conf.d
echo /usr/lib64 > /home/andreas/rpmbuild/BUILD/bpftune-0.1-build/BUILDROOT//etc/ld.so.conf.d/libbpftune.conf
if [ /home/andreas/rpmbuild/BUILD/bpftune-0.1-build/BUILDROOT =  / ]; then ldconfig; fi
make[2]: Leaving directory '/home/andreas/rpmbuild/BUILD/bpftune-0.1-build/bpftune-0.1/src'
cd include; make install
make[2]: Entering directory '/home/andreas/rpmbuild/BUILD/bpftune-0.1-build/bpftune-0.1/include'
install -dv -d /home/andreas/rpmbuild/BUILDROOT/bpftune-0.1-3.fc41.x86_64//usr/include/bpftune ; \
install -m 0444 bpftune/bpftune.bpf.h bpftune/bpftune.h bpftune/corr.h bpftune/libbpftune.h bpftune/rl.h bpftune/vmlinux_aarch64.h bpftune/vmlinux_x86_64.h -t /home/andreas/rpmbuild/BUILDROOT/bpftune-0.1-3.fc41.x86_64//usr/include/bpftune ; \

make[2]: Leaving directory '/home/andreas/rpmbuild/BUILD/bpftune-0.1-build/bpftune-0.1/include'
cd docs; make install
make[2]: Entering directory '/home/andreas/rpmbuild/BUILD/bpftune-0.1-build/bpftune-0.1/docs'
make[2]: Leaving directory '/home/andreas/rpmbuild/BUILD/bpftune-0.1-build/bpftune-0.1/docs'
make[1]: Leaving directory '/home/andreas/rpmbuild/BUILD/bpftune-0.1-build/bpftune-0.1'
```