### PR TITLE
reduce drop threshold to 1/64th of segs sent

### DIFF
--- a/docs/bpftune-tcp-conn.rst
+++ b/docs/bpftune-tcp-conn.rst
@@ -22,13 +22,14 @@ DESCRIPTION
         When we have limited information about a remote host - i.e. we have
         not had > REMOTE_HOST_MIN_INSTANCES connections involving it,
         the only auto-selection involved is to use BBR in cases where
-        loss rates exceed 1/32 of the packet sent rate - in such scenarions,
-        BBR performs much better than other congestion control algorithms.
+        loss rates exceed 1/(2^DROP_SHIFT) (1.5%) of the packet sent rate -
+        in such cases, BBR performs better than other congestion control
+        algorithms.
 
         For cases where we connect multiple times we can try different
         algorithms to select the best.
 
-        In selecting the appropriate congestion control algorithm, a reinforcement
+        In selecting the appropriate congestion control algorithm, a
         reinforcement learning-based method is used whereby we choose the
         congestion control algorithm that best fits the optimal bandwidth
         delay product (BDP)::

--- a/src/tcp_conn_tuner.bpf.c
+++ b/src/tcp_conn_tuner.bpf.c
@@ -95,7 +95,7 @@ int conn_tuner_sockops(struct bpf_sock_ops *ops)
 		break;
 	case BPF_SOCK_OPS_RETRANS_CB:
 		/* set individual cong algorithm to BBR if retransmit rate
-		 * is > 1/32 of packets out.
+		 * is > 1/(2^DROP_SHIFT) of packets out.
 		 */
 		if (ops->total_retrans > (ops->segs_out >> DROP_SHIFT)) {
 			if (sk) {

--- a/src/tcp_conn_tuner.h
+++ b/src/tcp_conn_tuner.h
@@ -74,10 +74,10 @@ struct remote_host {
 /* collect per-conn data once we see > REMOTE_HOST_MIN_INSTANCES */
 #define REMOTE_HOST_MIN_INSTANCES	4
 
-/* if total retrans/segs_out > 1(2^DROP_SHIFT) (1/32 by default)
+/* if total retrans/segs_out > 1(2^DROP_SHIFT) (1/64 by default)
  * apply BBR congestion control.
  */
-#define DROP_SHIFT	5
+#define DROP_SHIFT	6
 
 #define RTT_SCALE       1000000
 #define DELIVERY_SCALE  1000000

--- a/test/file_download_legacy_test.sh
+++ b/test/file_download_legacy_test.sh
@@ -20,7 +20,7 @@
 #
 
 # download file via wget with various drop/latencies; bbr should
-# be used when drops >= 2%
+# be used when drops >= 1.5%
 
 . ./test_lib.sh
 
@@ -30,8 +30,8 @@ SLEEPTIME=1
 TIMEOUT=30
 MAX_CONN=50
 
-for DROP_PERCENT in 2 0; do
-for LATENCY in "" "delay 100" ; do
+for DROP_PERCENT in 2 4 0; do
+for LATENCY in "" "delay 10" "delay 100"; do
 for NS in nonglobal global; do
  for FAMILY in ipv4 ipv6 ; do
    

--- a/test/file_download_test.sh
+++ b/test/file_download_test.sh
@@ -20,7 +20,7 @@
 #
 
 # download file via wget with various drop/latencies; bbr should
-# be used when drops >= 2%
+# be used when drops >= 1.5%
 
 . ./test_lib.sh
 
@@ -30,8 +30,8 @@ SLEEPTIME=1
 TIMEOUT=30
 MAX_CONN=50
 
-for DROP_PERCENT in 2 0; do
-for LATENCY in "" "delay 100" ; do
+for DROP_PERCENT in 2 4 0; do
+for LATENCY in "" "delay 10" "delay 100"; do
 for NS in nonglobal global; do
  for FAMILY in ipv4 ipv6 ; do
    


### PR DESCRIPTION
this is a ~1.5% drop rate which experiments show BBR to perform much better with than cubic or other algorithms since BBR does not just use loss as a signal.

Also update download tests to use a larger set of loss/latencies.