### PR TITLE
add optional summarize function to tuners

### DIFF
--- a/include/bpftune/bpftune.h
+++ b/include/bpftune/bpftune.h
@@ -184,6 +184,7 @@ struct bpftuner {
 	int netns_map_fd;
 	void (*event_handler)(struct bpftuner *tuner,
 			      struct bpftune_event *event, void *ctx);
+	void (*summarize)(struct bpftuner *tuner);
 	unsigned int num_tunables;
 	struct bpftunable *tunables;
 	unsigned int num_scenarios;

--- a/src/tcp_conn_tuner.c
+++ b/src/tcp_conn_tuner.c
@@ -84,7 +84,7 @@ error:
 	return 1;
 }
 
-static void summarize_conn_choices(struct bpftuner *tuner)
+void summarize(struct bpftuner *tuner)
 {
 	struct bpf_map *map = bpftuner_bpf_map_get(tcp_conn, tuner, remote_host_map);
 	struct in6_addr key, *prev_key = NULL;
@@ -138,7 +138,7 @@ void fini(struct bpftuner *tuner)
 {
 	bpftune_log(LOG_DEBUG, "calling fini for %s\n", tuner->name);
 	bpftuner_cgroup_detach(tuner, "conn_tuner_sockops", BPF_CGROUP_SOCK_OPS);
-	summarize_conn_choices(tuner);
+	summarize(tuner);
 	bpftuner_bpf_fini(tuner);
 }
 


### PR DESCRIPTION
most tuners we can summarize via sysctl data, but for tcp conn we need a callback to summarize; add an optional one to tuners.