### PR TITLE
tcp_conn_tuner: Fix cost calculation errors

### DIFF
--- a/src/tcp_conn_tuner.bpf.c
+++ b/src/tcp_conn_tuner.bpf.c
@@ -229,7 +229,7 @@ int conn_tuner_sockops(struct bpf_sock_ops *ops)
                 if (!m->max_rate_delivered || rate_delivered > m->max_rate_delivered)
                 	m->max_rate_delivered = rate_delivered;
 
-		metric = tcp_metric_calc(remote_host, min_rtt, m->max_rate_delivered);
+		metric = tcp_metric_calc(remote_host, min_rtt, rate_delivered);
 		event_data->state_flags = *statep;
 		event_data->min_rtt = min_rtt;
 		event_data->rate_delivered = rate_delivered;


### PR DESCRIPTION
We should use 'rate_delivered' instead of 'm->max_rate_delivered' to calculate the rate cost