### PR TITLE
fix a few issues aroud gcc-bpf compilation

### DIFF
--- a/include/bpftune/bpftune.bpf.h
+++ b/include/bpftune/bpftune.bpf.h
@@ -284,17 +284,6 @@ unsigned int bpftune_sample_rate = 4;
 
 extern const void init_net __ksym;
 
-static __always_inline int __strncmp(char *s1, char *s2, size_t n)
-{
-	size_t i;
-#pragma clang loop unroll(full)
-	for (i = 0; i < n; i++) {
-		if (s1[i] != s2[i])
-			return s1[i] - s2[i];
-	}
-	return 0;
-}
-
 static __always_inline long get_netns_cookie(struct net *net)
 {
 #ifndef BPFTUNE_NOBTF

--- a/src/Makefile
+++ b/src/Makefile
@@ -27,9 +27,10 @@ LLC ?= llc
 LLVM_STRIP ?= llvm-strip
 BPFTOOL ?= bpftool
 BPF_INCLUDE := /usr/include
+BPF_LOCAL_INCLUDE := /usr/local/include
 BPF_CFLAGS := -g -fno-stack-protector -Wall
 NL_INCLUDE := /usr/include/libnl3
-INCLUDES := -I../include -I$(BPF_INCLUDE) -I$(NL_INCLUDE) -I../include/uapi
+INCLUDES := -I../include -I$(BPF_INCLUDE) -I$(BPF_LOCAL_INCLUDE) -I$(NL_INCLUDE) -I../include/uapi
 INSTALL ?= install
 
 DESTDIR ?= /
@@ -193,6 +194,7 @@ $(NOBTF_BPF_OBJS): $(patsubst %.nobtf.o,%.c,$(NOBTF_BPF_OBJS)) ../include/bpftun
 else
 GCC_BPF_FLAGS := -g -O2 \
 	$(BPF_CFLAGS) -D__TARGET_ARCH_$(SRCARCH) \
+	-DBPF_NO_PRESERVE_ACCESS_INDEX \
 	-gbtf -mcpu=v3 -Wno-error=attributes \
 	-Wno-error=address-of-packed-member \
 	-Wno-compare-distinct-pointer-types \


### PR DESCRIPTION
no users of clang-unrolled strcnmp so remove it; also add definition for BPF_NO_PRESERVE_ACCESS_INDEX so that vmlinux.h inclusion does not trigger errors for clang push/pop of preserve access index