### PR TITLE
more gcc-bpf-related changes

### DIFF
--- a/include/bpftune/bpftune.bpf.h
+++ b/include/bpftune/bpftune.bpf.h
@@ -282,7 +282,7 @@ unsigned int bpftune_sample_rate = 4;
 #define bpftune_log(...)	__bpf_printk(__VA_ARGS__)
 #define bpftune_debug(...)	if (debug) __bpf_printk(__VA_ARGS__)
 
-extern const void init_net __ksym;
+extern const struct net init_net __ksym;
 
 static __always_inline long get_netns_cookie(struct net *net)
 {

--- a/include/bpftune/bpftune.bpf.h
+++ b/include/bpftune/bpftune.bpf.h
@@ -282,7 +282,9 @@ unsigned int bpftune_sample_rate = 4;
 #define bpftune_log(...)	__bpf_printk(__VA_ARGS__)
 #define bpftune_debug(...)	if (debug) __bpf_printk(__VA_ARGS__)
 
-extern const struct net init_net __ksym;
+#ifdef __clang__
+extern const void init_net __ksym;
+#endif
 
 static __always_inline long get_netns_cookie(struct net *net)
 {
@@ -290,7 +292,11 @@ static __always_inline long get_netns_cookie(struct net *net)
 	if (bpf_core_field_exists(net->net_cookie))
 		return BPFTUNE_CORE_READ(net, net_cookie);
 #endif
-	if (net == &init_net || net == (void *)bpftune_init_net)
+#ifdef __clang__
+	if (net == &init_net)
+	       return 0;
+#endif
+	if (net == (void *)bpftune_init_net)
 		return 0;
 	/* not global ns, no cookie support. */
 	return -1;

--- a/include/bpftune/vmlinux_aarch64.h
+++ b/include/bpftune/vmlinux_aarch64.h
@@ -1,8 +1,34 @@
 #ifndef __VMLINUX_H__
 #define __VMLINUX_H__
 
+#ifdef __clang__
 #ifndef BPF_NO_PRESERVE_ACCESS_INDEX
 #pragma clang attribute push (__attribute__((preserve_access_index)), apply_to = record)
+#endif
+#else
+#if defined(__BPF__)
+#define ATTR_PRESERVE_ACCESS_INDEX __attribute__((preserve_access_index))
+#endif
+#endif
+
+#ifndef ATTR_PRESERVE_ACCESS_INDEX
+#define ATTR_PRESERVE_ACCESS_INDEX
+#endif
+
+#ifndef __ksym
+#define __ksym __attribute__((section(".ksyms")))
+#endif
+
+#ifndef __weak
+#define __weak __attribute__((weak))
+#endif
+
+#ifndef __bpf_fastcall
+#if __has_attribute(bpf_fastcall)
+#define __bpf_fastcall __attribute__((bpf_fastcall))
+#else
+#define __bpf_fastcall
+#endif
 #endif
 
 typedef unsigned char __u8;
@@ -135251,8 +135277,10 @@ union efi_pci_io_protocol {
 	} mixed_mode;
 };
 
+#ifdef __clang__
 #ifndef BPF_NO_PRESERVE_ACCESS_INDEX
 #pragma clang attribute pop
+#endif
 #endif
 
 #endif /* __VMLINUX_H__ */

--- a/include/bpftune/vmlinux_x86_64.h
+++ b/include/bpftune/vmlinux_x86_64.h
@@ -1,8 +1,34 @@
 #ifndef __VMLINUX_H__
 #define __VMLINUX_H__
 
+#ifdef __clang__
 #ifndef BPF_NO_PRESERVE_ACCESS_INDEX
 #pragma clang attribute push (__attribute__((preserve_access_index)), apply_to = record)
+#endif
+#else
+#if defined(__BPF__)
+#define ATTR_PRESERVE_ACCESS_INDEX __attribute__((preserve_access_index))
+#endif
+#endif
+
+#ifndef ATTR_PRESERVE_ACCESS_INDEX
+#define ATTR_PRESERVE_ACCESS_INDEX
+#endif
+
+#ifndef __ksym
+#define __ksym __attribute__((section(".ksyms")))
+#endif
+
+#ifndef __weak
+#define __weak __attribute__((weak))
+#endif
+
+#ifndef __bpf_fastcall
+#if __has_attribute(bpf_fastcall)
+#define __bpf_fastcall __attribute__((bpf_fastcall))
+#else
+#define __bpf_fastcall
+#endif
 #endif
 
 typedef signed char __s8;
@@ -121951,8 +121977,10 @@ enum reg_type {
 	REG_TYPE_BASE = 3,
 };
 
+#ifdef __clang__
 #ifndef BPF_NO_PRESERVE_ACCESS_INDEX
 #pragma clang attribute pop
+#endif
 #endif
 
 #endif /* __VMLINUX_H__ */

--- a/src/Makefile
+++ b/src/Makefile
@@ -194,8 +194,7 @@ $(NOBTF_BPF_OBJS): $(patsubst %.nobtf.o,%.c,$(NOBTF_BPF_OBJS)) ../include/bpftun
 else
 GCC_BPF_FLAGS := -g -O2 \
 	$(BPF_CFLAGS) -D__TARGET_ARCH_$(SRCARCH) \
-	-DBPF_NO_PRESERVE_ACCESS_INDEX \
-	-gbtf -mcpu=v3 -Wno-error=attributes \
+	-gbtf -mcpu=v3 -mco-re -Wno-error=attributes \
 	-Wno-error=address-of-packed-member \
 	-Wno-compare-distinct-pointer-types \
 	$(INCLUDES)


### PR DESCRIPTION
support gcc-bpf preserve access index in vmlinux_<arch>.h