### PR TITLE
to support GCC_BPF, and -std=gnu17

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -116,6 +116,7 @@ BPFTUNE_HDRS = ../include/bpftune/libbpftune.h \
 ifeq ($(GCC_BPF),)
 all: analyze $(OPATH) $(OPATH)bpftune $(TUNER_LIBS)
 else
+BPF_CFLAGS += -std=gnu17
 all: $(OPATH) $(OPATH)bpftune $(TUNER_LIBS)
 endif
 

--- a/test/strategy/Makefile
+++ b/test/strategy/Makefile
@@ -106,7 +106,7 @@ $(NOBTF_BPF_OBJS): $(patsubst %.nobtf.o,%.c,$(NOBTF_BPF_OBJS)) ../../include/bpf
 
 else
 GCC_BPF_FLAGS := -g -O2 \
-	$(BPF_CFLAGS) -D__TARGET_ARCH_$(SRCARCH) \
+	$(BPF_CFLAGS) -std=gnu17 -D__TARGET_ARCH_$(SRCARCH) \
 	-gbtf -mcpu=v3 -Wno-error=attributes \
 	-Wno-error=address-of-packed-member \
 	-Wno-compare-distinct-pointer-types \


### PR DESCRIPTION
...as without this compilation fails for latest gcc bpf