### PR TITLE
Add Ansible Play to download, built, install and start bpftune

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,16 +318,16 @@ Information: If you are using an Fedora Upstream based Distribution you have to 
             chdir: "{{ repo_dest }}"
             target: all
 
+        - name: Run make with taget 'install' target for bpftune
+          community.general.make:
+            chdir: "{{ repo_dest }}"
+            target: install
+
         - name: Check bpftune status
           command: bpftune -S
           register: bpftune_status
           changed_when: false
           failed_when: "'bpftune works fully' not in bpftune_status.stderr"
-
-        - name: Run make with taget 'install' target for bpftune
-          community.general.make:
-            chdir: "{{ repo_dest }}"
-            target: install
 
         - name: restart and enable bpftune service
           ansible.builtin.service:


### PR DESCRIPTION
Adds an Ansible download, built, install and start play.

I tested it on Debian 12, Ubuntu 22, Rocky Linux 9.
The only Problem is, that on some fedoara based systems the libbpf-devel package is not provided in the default repository. I found a side where you can look through the different distributions and you get the information what repo you have to add. I thought also about implementing the system detection, scrabbing it from the site and usint it as a variable, but that would have been to difficult for me to do.

I hope it is self explaining what it does :)