### PR TITLE
bpftune: add adaptive sampling

### DIFF
--- a/include/bpftune/bpftune.h
+++ b/include/bpftune/bpftune.h
@@ -160,6 +160,19 @@ enum bpftune_support_level {
 	BPFTUNE_SUPPORT_NORMAL
 };
 
+struct bpftune_sample {
+	__u64 count;
+	__u64 ts;
+	__u64 rate;
+};
+
+struct bpftune_sample_desc {
+	const char *name;
+	struct bpftune_sample *sample;
+};
+
+#define BPFTUNE_MAX_SAMPLES	8
+
 struct bpftuner {
 	unsigned int id;
 	enum bpftune_state state;
@@ -189,6 +202,8 @@ struct bpftuner {
 	struct bpftunable *tunables;
 	unsigned int num_scenarios;
 	struct bpftunable_scenario *scenarios;
+	unsigned int num_samples;
+	struct bpftune_sample_desc samples[BPFTUNE_MAX_SAMPLES];
 };
 
 /* from include/linux/log2.h */

--- a/include/bpftune/libbpftune.h
+++ b/include/bpftune/libbpftune.h
@@ -312,6 +312,32 @@ void bpftuner_tunables_fini(struct bpftuner *tuner);
 #define bpftuner_bpf_map_get(tuner_name, tuner, map)			     \
 	bpftuner_bpf_skel_val(tuner_name, tuner, maps.map)
 
+#define bpftuner_bpf_sample_add(tuner_name, tuner, s)		     	     \
+	do {								     \
+		struct tuner_name##_tuner_bpf *__skel = tuner->skel;	     \
+		struct tuner_name##_tuner_bpf_legacy *__lskel = tuner->skel; \
+		struct tuner_name##_tuner_bpf_nobtf *__nskel = tuner->skel;  \
+		struct bpftune_sample_desc *d;				     \
+		d = &tuner->samples[tuner->num_samples];		     \
+		d->name = #s;						     \
+		switch (tuner->bpf_support) {				     \
+                case BPFTUNE_SUPPORT_NORMAL:				     \
+                        d->sample = &__skel->bss->s;			     \
+                        break;                                               \
+                case BPFTUNE_SUPPORT_LEGACY:                                 \
+                        d->sample = &__lskel->bss->s;			     \
+                        break;                                               \
+                case BPFTUNE_SUPPORT_NOBTF:                                  \
+                        d->sample = &__nskel->bss->s;			     \
+                default:						     \
+                        break;                                               \
+                }                                                            \
+		tuner->num_samples++;					     \
+                bpftune_log(LOG_DEBUG, "%s: added sample '%s'\n",	     \
+                            #tuner_name, #s);				     \
+	} while (0)
+
+
 enum bpftune_support_level bpftune_bpf_support(void);
 bool bpftune_have_vmlinux_btf(void);
 void bpftune_force_bpf_support(enum bpftune_support_level);

--- a/src/libbpftune.c
+++ b/src/libbpftune.c
@@ -791,6 +791,13 @@ void bpftuner_fini(struct bpftuner *tuner, enum bpftune_state state)
 
 	bpftune_log(LOG_DEBUG, "cleaning up tuner %s with %d tunables, %d scenarios\n",
 		    tuner->name, tuner->num_tunables, tuner->num_scenarios);
+	/* Show sample data before destroying BPF skeleton */
+	for (i = 0; i < tuner->num_samples; i++) {
+		bpftune_log(BPFTUNE_LOG_LEVEL, "Sample '%s': associated program was called %lu times, collected data every %lu of these.\n",
+			    tuner->samples[i].name,
+			    tuner->samples[i].sample->count,
+			    tuner->samples[i].sample->rate);
+	}
 	if (tuner->fini)
 		tuner->fini(tuner);
 	/* report summary of events for tuner */

--- a/src/net_buffer_tuner.c
+++ b/src/net_buffer_tuner.c
@@ -62,6 +62,8 @@ int init(struct bpftuner *tuner)
 			     budget);
 	bpftuner_bpf_var_set(net_buffer, tuner, netdev_budget_usecs,
 			     budget_usecs);
+	bpftuner_bpf_sample_add(net_buffer, tuner, drop_sample);
+	bpftuner_bpf_sample_add(net_buffer, tuner, rx_action_sample);
 	err = bpftuner_bpf_attach(net_buffer, tuner);
 	if (err)
 		return err;

--- a/src/tcp_buffer_tuner.c
+++ b/src/tcp_buffer_tuner.c
@@ -164,6 +164,7 @@ int init(struct bpftuner *tuner)
 			     ilog2(SK_MEM_QUANTUM));
 	bpftuner_bpf_var_set(tcp_buffer, tuner, nr_free_buffer_pages,
 			     nr_free_buffer_pages(true));
+	bpftuner_bpf_sample_add(tcp_buffer, tuner, rcv_space_sample);
 	err = bpftuner_bpf_attach(tcp_buffer, tuner);
 	if (err)
 		return err;

--- a/test/Makefile
+++ b/test/Makefile
@@ -24,7 +24,7 @@ TUNER_TESTS =	support_test log_test service_test inotify_test cap_test \
 		sample_test sample_legacy_test \
 		strategy_test strategy_legacy_test \
 		rollback_test rollback_legacy_test \
-		query_test \
+		query_test rate_test \
 		many_netns_test many_netns_legacy_test \
 		podman_globalonly_test podman_globalonly_legacy_test \
 		sysctl_test sysctl_legacy_test sysctl_netns_test \

--- a/test/rate_test.sh
+++ b/test/rate_test.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/bash
+#
+# SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note
+#
+# Copyright (c) 2023, Oracle and/or its affiliates.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License v2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public
+# License along with this program; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 021110-1307, USA.
+#
+
+# run iperf3 test with low rmem max, ensure sampling was used
+# on rcvbuf expand.
+
+PORT=5201
+
+. ./test_lib.sh
+
+SLEEPTIME=1
+TIMEOUT=30
+
+for FAMILY in ipv4 ipv6 ; do
+
+ for CLIENT_OPTS in "" "-R" ; do
+   case $FAMILY in
+   ipv4)
+   	ADDR=$VETH1_IPV4
+	;;
+   ipv6)
+	ADDR=$VETH1_IPV6
+	;;
+   esac
+
+   test_start "$0|rate test to $ADDR:$PORT $FAMILY opts $CLIENT_OPTS $LATENCY"
+
+   rmem_orig=($(sysctl -n net.ipv4.tcp_rmem))
+
+   test_setup true
+
+   rmem_orig_netns=($(ip netns exec $NETNS sysctl -n net.ipv4.tcp_rmem))
+
+   sysctl -w net.ipv4.tcp_rmem="${rmem_orig[0]} ${rmem_orig[1]} ${rmem_orig[1]}"
+   ip netns exec $NETNS sysctl -w net.ipv4.tcp_rmem="${rmem_orig_netns[0]} ${rmem_orig_netns[1]} ${rmem_orig_netns[1]}"
+
+   declare -A results
+   for MODE in baseline test ; do
+
+	echo "Running ${MODE}..."
+	test_run_cmd_local "ip netns exec $NETNS $IPERF3 -s -p $PORT -1 &"
+	if [[ $MODE != "baseline" ]]; then
+		test_run_cmd_local "$BPFTUNE -s &" true
+		sleep $SETUPTIME
+	else
+		LOGSZ=$(wc -l $LOGFILE | awk '{print $1}')
+		LOGSZ=$(expr $LOGSZ + 1)
+	fi
+	test_run_cmd_local "$IPERF3 -fm $CLIENT_OPTS -c $PORT -c $ADDR" true
+	sleep $SLEEPTIME
+   done
+
+   pkill -TERM bpftune
+   rmem_post=($(sysctl -n net.ipv4.tcp_rmem))
+   rmem_post_netns=($(ip netns exec $NETNS sysctl -n net.ipv4.tcp_rmem))
+   sysctl -w net.ipv4.tcp_rmem="${rmem_orig[0]} ${rmem_orig[1]} ${rmem_orig[2]}"
+   if [[ $MODE == "test" ]]; then
+	if [[ "${rmem_post[2]}" -gt ${rmem_orig[1]} ]]; then
+		echo "rmem before ${rmem_orig[1]} ; after ${rmem_post[2]}"
+
+		if [[ "${rmem_post_netns[2]}" -gt ${rmem_orig_netns[1]} ]]; then
+			echo "netns rmem before ${rmem_orig_netns[1]} ; after ${rmem_post_netns[2]}"
+		else
+			echo "netns rmem before ${rmem_orig_netns[1]} ; after ${rmem_post_netns[2]}"
+			if [[ ${BPFTUNE_NETNS} -eq 0 ]]; then
+				echo "bpftune does not support per-netns policy, skipping..."
+			else
+				test_cleanup
+			fi
+		fi
+	else
+		test_cleanup
+	fi
+   fi
+   sleep $SLEEPTIME
+
+   grep "Sample" $TESTLOG_LAST
+
+   test_pass
+
+   test_cleanup
+ done
+done
+
+test_exit


### PR DESCRIPTION
One approach to reducing overhead is to introduce sampling; i.e. a high-frequency program bails early and only does more expensive work for 1 out of every N invokations.  bpftune has adaptive sampling to support this.  It works as follows.

In your BPF object, add a struct bpftune_sample variable for the BPF program you wish to sample.  For example in tcp_buffer_tuner.bpf.c we have

```
struct bpftune_sample rcv_space_sample = { };
```

Since tcp_rcv_space_adjust() is called frequently, add the following early in function lifetime:

```
        bpftune_sample(rcv_space_sample);
```

The above will bail if it is not the Nth invokation of the program. Note that N is usually bpftune_sample_rate - default 4 - but will be adaptively adjusted if the program runs too frequently.  Too frequently is 2N instances - i.e. collecting data twice - in a 10 msec interval.  In such cases we double the sample rate.  Similarly if we fall outside that range we lower the sample rate towards bpftune_sample_rate, so over time it should adjust to handle the rate of invokations adaptively.

To add reporting to your tuner on exit (how many times the program was invoked and what fraction of these we collected data for), in the init method add

```
                bpftuner_bpf_sample_add(tcp_buffer, tuner, rcv_space_sample);
```

Then on tuner fini, you will see something like:

```
bpftune: Sample 'rcv_space_sample': associated program was called 598663 times, collected data every 2048 of these.
```

In this case the frequency dictated we increase the fractional rate of data collection from 1 in 4 to 1 in 2048.

With this in place, overheads recorded via stress-ng are much reduced.