### PR TITLE
test: add stress-ng tests

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -18,7 +18,7 @@
 #
 
 
-PERF_TESTS = iperf3_test qperf_test
+PERF_TESTS = stress_ng_test iperf3_test qperf_test
 
 TUNER_TESTS =	support_test log_test service_test inotify_test cap_test \
 		sample_test sample_legacy_test \

--- a/test/stress_ng_test.sh
+++ b/test/stress_ng_test.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/bash
+#
+# SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note
+#
+# Copyright (c) 2023, Oracle and/or its affiliates.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License v2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public
+# License along with this program; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 021110-1307, USA.
+#
+
+# run socket stress-ng test in baseline/test to compare differences
+# in ops/sec
+
+. ./test_lib.sh
+
+LOGFILE=$TESTLOG_LAST
+
+SLEEPTIME=1
+TIMEOUT=30
+MAX_CONN=50
+
+for SOCKS in 10 1000; do 
+   test_start "$0|stress-ng test, $SOCKS sockets"
+
+   test_setup true
+
+   set +e
+   FIREWALLD_PID=$(pgrep firewalld)
+   set -e
+   if [[ -n "$FIREWALLD_PID" ]]; then
+      service firewalld stop
+   fi
+   for MODE in baseline test ; do
+
+	echo "Running ${MODE}..."
+	if [[ $MODE != "baseline" ]]; then
+		test_run_cmd_local "$BPFTUNE -sR &" true
+		sleep $SETUPTIME
+	fi
+	LOGSZ=$(wc -l $LOGFILE | awk '{print $1}')
+	LOGSZ=$(expr $LOGSZ + 1)
+	export TIMEOUT=60
+	test_run_cmd_local "stress-ng -S $SOCKS --metrics -t 30" true
+	export TIMEOUT=30
+	tail -n +${LOGSZ} $LOGFILE | grep stress-ng
+	if [[ $MODE != "baseline" ]]; then
+	    $BPFTUNE_PROG -q summary
+	    pkill -TERM bpftune
+	    sleep $SETUPTIME
+	fi
+   done
+   if [[ -n "$FIREWALLD_PID" ]]; then
+      service firewalld start
+   fi
+   test_pass	
+   test_cleanup
+done
+
+test_exit

--- a/test/test_lib.sh
+++ b/test/test_lib.sh
@@ -60,6 +60,8 @@ check_prog "$IPERF3" iperf3 iperf3
 export QPERF=$(which qperf 2>/dev/null)
 export NC=$(which nc 2>/dev/null)
 check_prog "$NC" nc nmap-netcat
+export STRESS_NG=$(which stress-ng 2>/dev/null)
+check_prog "$STRESS_NG" stress-ng stress-ng
 export FIREWALL_CMD=$(which firewall-cmd 2>/dev/null)
 export AUDIT_CMD=$(which auditctl 2>/dev/null)
 export SYSLOGFILE=${SYSLOGFILE:-"/var/log/messages"}


### PR DESCRIPTION
tests that compare bogo ops/s for 10, 1000 sockets in baseline, bpftune running modes and examine which tunables were updated.