### PR TITLE
Rollback fix

### DIFF
--- a/src/libbpftune.c
+++ b/src/libbpftune.c
@@ -782,63 +782,48 @@ static void __bpftuner_scenario_log(struct bpftuner *tuner, unsigned int tunable
 #define bpftuner_scenario_log(tuner, tunable, scenario, netns_fd, summary) \
 	__bpftuner_scenario_log(tuner, tunable, scenario, netns_fd, summary, NULL, NULL)
 
-void bpftuner_fini(struct bpftuner *tuner, enum bpftune_state state)
+static void bpftuner_rollback(struct bpftuner *tuner, bool log_only)
 {
 	unsigned int i, j, k;
 
-	if (!tuner || tuner->state != BPFTUNE_ACTIVE)
+	if (!tuner || (!log_only && !tuner->rollback))
 		return;
 
-	bpftune_log(LOG_DEBUG, "cleaning up tuner %s with %d tunables, %d scenarios\n",
-		    tuner->name, tuner->num_tunables, tuner->num_scenarios);
-	/* Show sample data before destroying BPF skeleton */
-	for (i = 0; i < tuner->num_samples; i++) {
-		bpftune_log(BPFTUNE_LOG_LEVEL, "Sample '%s': associated program was called %lu times, collected data every %lu of these.\n",
-			    tuner->samples[i].name,
-			    tuner->samples[i].sample->count,
-			    tuner->samples[i].sample->rate);
-	}
-	if (tuner->fini)
-		tuner->fini(tuner);
-	/* report summary of events for tuner */
 	for (i = 0; i < tuner->num_tunables; i++) {
-		for (j = 0; j < tuner->num_scenarios; j++) {
-			bpftune_log(LOG_DEBUG, "checking scenarios for tuner %d, scenario %d\n",
-				    i, j);
-			bpftuner_scenario_log(tuner, i, j, 0, true);
-			bpftuner_scenario_log(tuner, i, j, 1, true);
-		}
-	}
-	if (tuner->rollback) {
-		for (i = 0; i < tuner->num_tunables; i++) {
-			struct bpftunable *t = bpftuner_tunable(tuner, i);
-			char oldvals[PATH_MAX] = { };
-			char newvals[PATH_MAX] = { };
-			bool changes = false;
-			char s[PATH_MAX];
+		struct bpftunable *t = bpftuner_tunable(tuner, i);
+		char oldvals[PATH_MAX] = { };
+		char newvals[PATH_MAX] = { };
+		bool changes = false;
+		char s[PATH_MAX];
 
-			k = 0;
-			/* find dominant scenario for tunable; if a tunable
-			 * increases and decreases, need to choose description
-			 * that best matches.
-			 */
-			for (j = 0; j < tuner->num_scenarios; j++) {
-				if (t->stats.global_ns[j])
-					changes = true;
-				if (t->stats.global_ns[j] > k)
-					k = j;
-			}
-			/* nothing to rollback? */
-			if (!changes)
-				continue;
-			for (j = 0; j < t->desc.num_values; j++) {
-				snprintf(s, sizeof(s), "%ld ",
-					 t->initial_values[j]);
-				strcat(oldvals, s);
-				snprintf(s, sizeof(s), "%ld ",
-					 t->current_values[j]);
-				strcat(newvals, s);
-			}
+		k = 0;
+		/* find dominant scenario for tunable; if a tunable
+		 * increases and decreases, need to choose description
+		 * that best matches.
+		 */
+		for (j = 0; j < tuner->num_scenarios; j++) {
+			if (t->stats.global_ns[j])
+				changes = true;
+			if (t->stats.global_ns[j] > k)
+				k = j;
+		}
+		/* nothing to rollback? */
+		if (!changes)
+			continue;
+		for (j = 0; j < t->desc.num_values; j++) {
+			snprintf(s, sizeof(s), "%ld ",
+				 t->initial_values[j]);
+			strcat(oldvals, s);
+			snprintf(s, sizeof(s), "%ld ",
+				 t->current_values[j]);
+			strcat(newvals, s);
+		}
+		if (log_only) {
+			bpftune_log(BPFTUNE_LOG_LEVEL, "# To roll back changes to '%s', run the following in a terminal:\n",
+				   t->desc.name);
+			bpftune_log(BPFTUNE_LOG_LEVEL, "sudo sysctl -w %s=\"%s\"\n",
+				    t->desc.name, oldvals);
+		} else {
 			bpftuner_tunable_sysctl_write(tuner, i, k,
 				0,
 				t->desc.num_values,
@@ -846,9 +831,38 @@ void bpftuner_fini(struct bpftuner *tuner, enum bpftune_state state)
 				"Rolling back sysctl values for '%s' from (%s) to original values (%s)...\n",
 				t->desc.name,
 				newvals, oldvals);
+			}
 		}
 	}
 
+void bpftuner_fini(struct bpftuner *tuner, enum bpftune_state state)
+{
+        unsigned int i, j;
+
+        if (!tuner || tuner->state != BPFTUNE_ACTIVE)
+                return;
+
+        bpftune_log(LOG_DEBUG, "cleaning up tuner %s with %d tunables, %d scenarios\n",
+                    tuner->name, tuner->num_tunables, tuner->num_scenarios);
+        /* Show sample data before destroying BPF skeleton */
+        for (i = 0; i < tuner->num_samples; i++) {
+                bpftune_log(BPFTUNE_LOG_LEVEL, "Sample '%s': associated program was called %lu times, collected data every %lu of these.\n",
+                            tuner->samples[i].name,
+                            tuner->samples[i].sample->count,
+                            tuner->samples[i].sample->rate);
+        }
+        if (tuner->fini)
+                tuner->fini(tuner);
+        /* report summary of events for tuner */
+        for (i = 0; i < tuner->num_tunables; i++) {
+                for (j = 0; j < tuner->num_scenarios; j++) {
+                        bpftune_log(LOG_DEBUG, "checking scenarios for tuner %d, scenario %d\n",
+                                    i, j);
+                        bpftuner_scenario_log(tuner, i, j, 0, true);
+                        bpftuner_scenario_log(tuner, i, j, 1, true);
+                }
+        }
+	bpftuner_rollback(tuner, false);
 
 	tuner->state = state;
 }
@@ -1337,7 +1351,7 @@ static void __bpftuner_scenario_log(struct bpftuner *tuner, unsigned int tunable
 				    t->stats.nonglobal_ns[scenario];
 		if (!count)
 			return;
-		bpftune_log(BPFTUNE_LOG_LEVEL, "Summary: scenario '%s' occurred %ld times for tunable '%s' in %sglobal ns. %s\n",
+		bpftune_log(BPFTUNE_LOG_LEVEL, "# Summary: scenario '%s' occurred %ld times for tunable '%s' in %sglobal ns. %s\n",
 			    tuner->scenarios[scenario].name, count,
 			    t->desc.name,
 			    global_ns ? "" : "non-",
@@ -1356,8 +1370,11 @@ static void __bpftuner_scenario_log(struct bpftuner *tuner, unsigned int tunable
 					 t->current_values[i]);
 				strcat(newvals, s);
 			}
-			bpftune_log(BPFTUNE_LOG_LEVEL, "sysctl '%s' changed from (%s) -> (%s)\n",
+			bpftune_log(BPFTUNE_LOG_LEVEL, "# sysctl '%s' changed from (%s) -> (%s)\n",
 				    t->desc.name, oldvals, newvals);
+			bpftune_log(BPFTUNE_LOG_LEVEL, "# To replicate this change on another system, run the following in a terminal:\n");
+			bpftune_log(BPFTUNE_LOG_LEVEL, "sudo sysctl -w %s=\"%s\"\n",
+				    t->desc.name, newvals);
 		}
 	} else {
 		bpftune_log(BPFTUNE_LOG_LEVEL, "Scenario '%s' occurred for tunable '%s' in %sglobal ns. %s\n",
@@ -2006,6 +2023,7 @@ static void bpftune_help_handler(const char *req, char *buf, size_t buf_sz);
 static void bpftune_tuners_handler(const char *req, char *buf, size_t buf_sz);
 static void bpftune_tunables_handler(const char *req, char *buf, size_t buf_sz);
 static void bpftune_summary_handler(const char *req, char *buf, size_t buf_sz);
+static void bpftune_rollback_handler(const char *req, char *buf, size_t buf_sz);
 
 /* add bpftune server requests with handlers here */
 struct bpftune_req bpftune_reqs[] = {
@@ -2013,6 +2031,8 @@ struct bpftune_req bpftune_reqs[] = {
  { "tuners",	"show state of tuners",		bpftune_tuners_handler },
  { "tunables",	"show list of tunables",	bpftune_tunables_handler },
  { "summary",	"show summary of changes",	bpftune_summary_handler },
+ { "rollback",	"show changes needed to roll back",
+	 					bpftune_rollback_handler }
 };
 
 static void bpftune_help_handler(__attribute__((unused)) const char *req,
@@ -2065,7 +2085,7 @@ static void bpftune_summary_handler(__attribute__((unused)) const char *req,
 	int off = 0;
 
 	off = snprintf(buf, buf_sz,
-		       "Summary of changes made across all tuners:\n");
+		       "# Summary of changes made across all tuners:\n");
 	ctx_buf.nextlogfn = bpftune_logfn;
 	ctx_buf.buf = buf;
 	ctx_buf.buf_off = off;
@@ -2092,6 +2112,30 @@ static void bpftune_summary_handler(__attribute__((unused)) const char *req,
 	bpftune_set_log(bpftune_loglevel, ctx_buf.nextlogfn, NULL);
 	bpftune_log(LOG_DEBUG, "got the following sz %d off %d, orig off %d '%s'\n",
 		    ctx_buf.buf_sz, ctx_buf.buf_off, off, buf);
+}
+
+static void bpftune_rollback_handler(__attribute__((unused)) const char *req,
+				     char *buf, size_t buf_sz)
+{
+	struct bpftune_log_ctx_buf ctx_buf;
+	struct bpftuner *t;
+	int off = 0;
+
+	off = snprintf(buf, buf_sz,
+		       "# Summary of rollback operations needed to restore original state for all tuners:\n");
+	ctx_buf.nextlogfn = bpftune_logfn;
+	ctx_buf.buf = buf;
+	ctx_buf.buf_off = off;
+	ctx_buf.buf_sz = buf_sz;
+	ctx_buf.buf_thread = pthread_self();
+
+        /* have rollback log to buffer + usual log destination */
+	bpftune_set_log(bpftune_loglevel, bpftune_log_buf, &ctx_buf);
+
+	bpftune_for_each_tuner(t) {
+		bpftuner_rollback(t, true);
+	}
+	bpftune_set_log(bpftune_loglevel, ctx_buf.nextlogfn, NULL);
 }
 
 static bool bpftune_server_running = false;

--- a/src/tcp_conn_tuner.c
+++ b/src/tcp_conn_tuner.c
@@ -96,11 +96,11 @@ void summarize(struct bpftuner *tuner)
 	cong_choices = bpftuner_bpf_var_get(tcp_conn, tuner, tcp_cong_choices);
 	if (cong_choices) {
 		bpftune_log(BPFTUNE_LOG_LEVEL,
-			    "Summary: tcp_conn_tuner: %20s %20s\n",
+			    "# Summary: tcp_conn_tuner: %20s %20s\n",
 			    "CongAlg", "Count");
 		for (i = 0; i < NUM_TCP_CONG_ALGS; i++) {
 			bpftune_log(BPFTUNE_LOG_LEVEL,
-				    "Summary: tcp_conn_tuner: %20s %20lu\n",
+				    "# Summary: tcp_conn_tuner: %20s %20lu\n",
 				    congs[i], cong_choices[i]);
 		}
 	}
@@ -113,13 +113,13 @@ void summarize(struct bpftuner *tuner)
 		if (bpf_map_lookup_elem(map_fd, &key, &r))
 			continue;
 
-		bpftune_log(LOG_DEBUG, "Summary: tcp_conn_tuner: %48s %8s %20s %8s %8s %8s %8s\n",
+		bpftune_log(LOG_DEBUG, "# Summary: tcp_conn_tuner: %48s %8s %20s %8s %8s %8s %8s\n",
 			    "IPAddress", "CongAlg", "Metric", "Count", "Greedy", "MinRtt", "MaxDlvr");
 		inet_ntop(AF_INET6, &key, buf, sizeof(buf));
 
 		for (i = 0; i < NUM_TCP_CONN_METRICS; i++) {
 
-			bpftune_log(LOG_DEBUG, "Summary: tcp_conn_tuner: %48s %8s %20llu %8llu %8llu %8llu %8llu\n",
+			bpftune_log(LOG_DEBUG, "# Summary: tcp_conn_tuner: %48s %8s %20llu %8llu %8llu %8llu %8llu\n",
 				    buf, congs[i],
 				    r.metrics[i].metric_value,
 				    r.metrics[i].metric_count,

--- a/test/query_test.sh
+++ b/test/query_test.sh
@@ -39,6 +39,7 @@ for QUERY in help tuners tunables ; do
 done
 test_cleanup
 
+for QUERY in summary rollback ; do 
 for FAMILY in ipv4 ; do
  for NS in global; do
    case $FAMILY in
@@ -62,7 +63,7 @@ for FAMILY in ipv4 ; do
 	;;
    esac
 
-   test_start "$0|query summary test to $ADDR:$PORT $FAMILY $NS"
+   test_start "$0|query $QUERY test to $ADDR:$PORT $FAMILY $NS"
 
    if [[ $NS == "global" ]]; then
 	 CLIENT_PREFIX="ip netns exec $NETNS"
@@ -123,7 +124,7 @@ for FAMILY in ipv4 ; do
    if [[ $MODE == "test" ]]; then
 	if [[ "${frag_post}" -gt ${frag_pre} ]]; then
 		grep "approaching fragmentation maximum threshold" $LOGFILE
-		${BPFTUNE_PROG} -q summary
+		${BPFTUNE_PROG} -q $QUERY
 		pkill -TERM bpftune
 		test_pass
 	else
@@ -134,6 +135,7 @@ for FAMILY in ipv4 ; do
 
    test_cleanup
  done
+done
 done
 
 test_exit


### PR DESCRIPTION
these changes fix issues in rollback and provide a "rollback" query which gives a paste-able set of commands to restore to pre-bpftune sysctl settings 