### PR TITLE
tcp_buffer_tuner: remove tracing for cookie v[46] check

### DIFF
--- a/include/bpftune/libbpftune.h
+++ b/include/bpftune/libbpftune.h
@@ -352,6 +352,7 @@ int bpftune_sysctl_read(int netns_fd, const char *name, long *values);
 int bpftune_sysctl_write(int netns_fd, const char *name, __u8 num_values, long *values);
 long long bpftune_ksym_addr(char type, const char *name);
 int bpftune_snmpstat_read(unsigned long netns_cookie, int family, const char *name, long *value);
+int bpftune_netstat_read(unsigned long netns_cookie, int family, const char *name, long *value);
 int bpftune_sched_wait_run_percent_read(void);
 bool bpftune_netns_cookie_supported(void);
 int bpftune_netns_set(int fd, int *orig_fd, bool quiet);

--- a/src/libbpftune.map
+++ b/src/libbpftune.map
@@ -56,6 +56,7 @@ LIBBPFTUNE_0.1.1 {
 		bpftune_sysctl_read;
 		bpftune_sysctl_write;
 		bpftune_ksym_addr;
+		bpftune_netstat_read;
 		bpftune_snmpstat_read;
 		bpftune_sched_wait_run_percent_read;
 		bpftune_netns_init_all;

--- a/test/many_netns_test.sh
+++ b/test/many_netns_test.sh
@@ -52,7 +52,7 @@ for FAMILY in ipv4 ipv6 ; do
 	;;
    esac
 
-   test_start "$0|wmem test to $ADDR:$PORT $FAMILY opts $CLIENT_OPTS $LATENCY"
+   test_start "$0|many netns test to $ADDR:$PORT $FAMILY opts $CLIENT_OPTS $LATENCY"
 
    wmem_orig=($(sysctl -n net.ipv4.tcp_wmem))
 
@@ -95,6 +95,17 @@ for FAMILY in ipv4 ipv6 ; do
         fi
 	sleep $SLEEPTIME
    done
+
+   fds=$($LSOF -p $(pgrep bpftune) 2>/dev/null|wc -l)
+   # if we have 20 more than the original number of fds open, likely a leak
+   fdsX=${fds_orig}+20
+   if [[ "$fds" -gt $fdsX ]]; then
+        echo "bpftune has $fds open versus original $fds_orig; fd leak? files:"
+        $LSOF -p $(pgrep bpftune)
+        test_cleanup
+   fi
+   echo "found $fds fds open for bpftune"
+   pkill -TERM bpftune
 
    wmem_post=($(sysctl -n net.ipv4.tcp_wmem))
    wmem_post_netns=($(ip netns exec $NETNS sysctl -n net.ipv4.tcp_wmem))
@@ -139,16 +150,6 @@ for FAMILY in ipv4 ipv6 ; do
 		echo "baseline (${rbase}) < test (${rtest})"
 	fi
    done 
-
-   fds=$($LSOF -p $(pgrep bpftune) 2>/dev/null|wc -l)
-   # if we have 20 more than the original number of fds open, likely a leak
-   fdsX=${fds_orig}+20
-   if [[ "$fds" -gt $fdsX ]]; then
-        echo "bpftune has $fds open versus original $fds_orig; fd leak? files:"
-	$LSOF -p $(pgrep bpftune)
-        test_cleanup
-   fi
-   echo "found $fds fds open for bpftune"
 
    test_pass
 


### PR DESCRIPTION
...since we can get values via /proc/net/netstat, and func signature changes between kernel versions making fexit infeasible. Also clean up many_netns_test to be more robust.