### PR TITLE
stress-ng-test: limit to 500 socket test

### DIFF
--- a/test/stress_ng_test.sh
+++ b/test/stress_ng_test.sh
@@ -28,9 +28,9 @@ LOGFILE=$TESTLOG_LAST
 
 SLEEPTIME=1
 TIMEOUT=30
-MAX_CONN=50
+MAX_CONN=500
 
-for SOCKS in 10 1000; do 
+for SOCKS in 10 $MAX_CONN ; do 
    test_start "$0|stress-ng test, $SOCKS sockets"
 
    test_setup true


### PR DESCRIPTION
1000 socket test is too much for some VMs, limit to 500.