### PR TITLE
tcp_conn_tuner: set thin linear timeouts on a per-conn basis

### DIFF
--- a/docs/bpftune-tcp-conn.rst
+++ b/docs/bpftune-tcp-conn.rst
@@ -124,6 +124,9 @@ DESCRIPTION
         and it matches dctcp for minimum RTT (3us) and maximum delivery rate is
         close (9377 for dctcp, 8951 for cubic).
 
+        In addition, when retransmits occur for a TCP connection, we enable
+        TCP thin linear timeouts to improve responsiveness for thin TCP connections.
+
         References:
 
         BBR: Congestion-Based Congestion Control

--- a/src/tcp_conn_tuner.h
+++ b/src/tcp_conn_tuner.h
@@ -21,6 +21,7 @@
 
 enum tcp_cong_tunables {
 	TCP_CONG,
+	TCP_THIN_LINEAR_TIMEOUTS
 };
 
 enum tcp_cong_scenarios {


### PR DESCRIPTION
...for lossy connections if net.ipv4.tcp_thin_linear_timeouts = 0. This ensures that thin TCP connections will avoid exponential backoff costs in cases of loss so be more responsive.