### PR TITLE
libbpftune: add support for json queries of tunables, state

### DIFF
--- a/docs/bpftune.rst
+++ b/docs/bpftune.rst
@@ -101,3 +101,8 @@ OPTIONS
                 summary     - show summary of changes made by tuners
                 tuners      - show loaded tuners and their state
                 tunables    - show supported tunables for loaded tuners
+                jtunables   - show supported tunables in json format
+                status      - show current status of tunables
+                jstatus     - show current status of tunables in json format
+                rollback    - show changes needed to roll back changes made
+                              by bpftune

--- a/src/netns_tuner.c
+++ b/src/netns_tuner.c
@@ -29,7 +29,7 @@ struct netns_tuner_bpf *skel;
 
 static struct bpftunable_desc descs[] = {
 {
- NETNS, BPFTUNABLE_OTHER, "Network namespace", BPFTUNABLE_NAMESPACED, 0 },
+ NETNS, BPFTUNABLE_OTHER, "network_namespace", BPFTUNABLE_NAMESPACED, 0 },
 };
 
 static struct bpftunable_scenario scenarios[] = {

--- a/src/tcp_conn_tuner.c
+++ b/src/tcp_conn_tuner.c
@@ -34,7 +34,7 @@
 
 static struct bpftunable_desc descs[] = {
  
-{ TCP_CONG, BPFTUNABLE_OTHER, "Per-socket TCP congestion control", 0, 0 },
+{ TCP_CONG, BPFTUNABLE_OTHER, "net.persock.tcp.congestion_control", 0, 0 },
 { TCP_ALLOWED_CONG, BPFTUNABLE_SYSCTL, "net.ipv4.tcp_allowed_congestion_control",
   BPFTUNABLE_NAMESPACED | BPFTUNABLE_STRING, 1 },
 { TCP_AVAILABLE_CONG, BPFTUNABLE_SYSCTL, "net.ipv4.tcp_available_congestion_control",

--- a/test/query_test.sh
+++ b/test/query_test.sh
@@ -39,7 +39,19 @@ for QUERY in help tuners tunables ; do
 done
 test_cleanup
 
-for QUERY in summary rollback ; do 
+if [[ -n "$JQ_CMD" ]]; then
+   test_setup true
+   for JQUERY in jtunables jstatus ; do
+	test_start "$0|query $JQUERY test"
+	test_run_cmd_local "$BPFTUNE -s &" true
+	sleep $SETUPTIME
+	$BPFTUNE_CMD -q $JQUERY | $JQ_CMD
+	test_pass
+    done
+    test_cleanup
+fi
+
+for QUERY in summary rollback status ; do 
 for FAMILY in ipv4 ; do
  for NS in global; do
    case $FAMILY in

--- a/test/test_lib.sh
+++ b/test/test_lib.sh
@@ -66,6 +66,7 @@ export HPING=$(which hping3 2>/dev/null)
 check_prog "$HPING" hping3 hping3
 export FIREWALL_CMD=$(which firewall-cmd 2>/dev/null)
 export AUDIT_CMD=$(which auditctl 2>/dev/null)
+export JQ_CMD=$(which jq 2>/dev/null)
 export SYSLOGFILE=${SYSLOGFILE:-"/var/log/messages"}
 if [[ ! -f $SYSLOGFILE ]]; then
 	export SYSLOGFILE="/var/log/syslog"


### PR DESCRIPTION
this will be hepful in adding PCP support as JSON format is easier to parse.  Two new queries are added:

           jtunables              show list of tunables(json)
             jstatus            show status of tunables(json)