### PR TITLE
libbpftune: quiet clang analyzer complaints about unfreed memory

### DIFF
--- a/src/libbpftune.c
+++ b/src/libbpftune.c
@@ -57,6 +57,10 @@ unsigned short bpftune_learning_rate;
 #include <bpf/bpf.h>
 #include <bpf/libbpf.h>
 
+/* quiet clang analyzer false positive leak complaints */
+#ifdef __clang_analyzer__
+#define bpf_object__destroy_skeleton free
+#endif
 #include "probe.skel.h"
 #include "probe.skel.legacy.h"
 #include "probe.skel.nobtf.h"


### PR DESCRIPTION
Because the clang analyzer does not look into libraries, it thinks the BPF skeleton objects calloc()ed in BPF skeletons are not freed because a wrapper function is used to free them.  Work around this to convince the analyzer the memory is freed since we cannot change the bpftool-generated skeletons.