### PR TITLE
inotify_test: improve robustness by sleeping before removing tuner

### DIFF
--- a/test/inotify_test.sh
+++ b/test/inotify_test.sh
@@ -36,10 +36,10 @@ for TUNER in neigh_table ; do
 
    sleep $SETUPTIME
 
+   sleep $SLEEPTIME
    cp /usr/lib64/bpftune/tcp_buffer_tuner.so /tmp
    rm /usr/lib64/bpftune/tcp_buffer_tuner.so
    
-   sleep $SLEEPTIME
    grep "fini tuner" $TESTLOG_LAST
 
    sleep $SLEEPTIME


### PR DESCRIPTION
inotify test removes the tcp buffer tuner but on some systems it takes a while for it to be set up; move the sleep prior to the 'rm'.