### PR TITLE
neigh_table_tuner: tune all thresholds and limit growth

### DIFF
--- a/src/neigh_table_tuner.bpf.c
+++ b/src/neigh_table_tuner.bpf.c
@@ -43,6 +43,8 @@ int BPF_PROG(bpftune_neigh_create, struct neigh_table *tbl,
 
 		new_tbl_stats.family = BPFTUNE_CORE_READ(tbl, family);
 		new_tbl_stats.entries = BPFTUNE_CORE_READ(tbl, entries.counter);
+		new_tbl_stats.thresh1 = BPFTUNE_CORE_READ(tbl, gc_thresh1);
+		new_tbl_stats.thresh2 = BPFTUNE_CORE_READ(tbl, gc_thresh2);
 		new_tbl_stats.max = BPFTUNE_CORE_READ(tbl, gc_thresh3);
 		if (dev) {
 			bpf_probe_read(&new_tbl_stats.dev, sizeof(new_tbl_stats.dev), dev);
@@ -55,6 +57,8 @@ int BPF_PROG(bpftune_neigh_create, struct neigh_table *tbl,
 	}
 	tbl_stats->entries = BPFTUNE_CORE_READ(tbl, entries.counter);
 	tbl_stats->gc_entries = BPFTUNE_CORE_READ(tbl, gc_entries.counter);
+	tbl_stats->thresh1 = BPFTUNE_CORE_READ(tbl, gc_thresh1);
+	tbl_stats->thresh2 = BPFTUNE_CORE_READ(tbl, gc_thresh2);
 	tbl_stats->max = BPFTUNE_CORE_READ(tbl, gc_thresh3);
 
 	/* exempt from gc entries are not subject to space constraints, but

--- a/src/neigh_table_tuner.h
+++ b/src/neigh_table_tuner.h
@@ -45,6 +45,8 @@ struct tbl_stats {
 	int family;
 	int entries;
 	int gc_entries;
+	int thresh1;
+	int thresh2;
 	int max;
 	int ifindex;
 	char dev[IFNAMSIZ];


### PR DESCRIPTION
increase all thresholds simultaneously instead of only gc_thresh3. Also set a limit to how large the thresholds can grow