### PR TITLE
fix i386 build

### DIFF
--- a/src/udp_buffer_tuner.bpf.c
+++ b/src/udp_buffer_tuner.bpf.c
@@ -32,7 +32,7 @@ int sk_mem_quantum;
 int sk_mem_quantum_shift;
 unsigned long long nr_free_buffer_pages;
 
-long rmem_max, rmem_default;
+long long rmem_max, rmem_default;
 
 struct bpftune_sample udp_fail_rcv_sample = { };
 


### PR DESCRIPTION
Seeing errors

34495 |         _Static_assert(sizeof(s->bss->rmem_max) == 8, "unexpected size of 'rmem_max'");
       |                        ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
./udp_buffer_tuner.skel.nobtf.h:34496:17: error: static assertion failed due to requirement 'sizeof (s->bss->rmem_default) == 8': unexpected size of 'rmem_default'
 34496 |         _Static_assert(sizeof(s->bss->rmem_default) == 8, "unexpected size of 'rmem_default'");
       |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./udp_buffer_tuner.skel.nobtf.h:34496:46: note: expression evaluates to '4 == 8'
 34496 |         _Static_assert(sizeof(s->bss->rmem_default) == 8, "unexpected size of 'rmem_default'");
       |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
6 errors generated.
make[2]: *** [Makefile:137: analyze] Error 1

Make fix similar to tcp_buffer_tuner.bpf.c

Reported-by: https://github.com/sudipm-mukherjee