### PR TITLE
vmlinux_[arch].h: avoid negative enum values

### DIFF
--- a/include/bpftune/vmlinux_aarch64.h
+++ b/include/bpftune/vmlinux_aarch64.h
@@ -26221,7 +26221,6 @@ enum rpm_request {
 };
 
 enum rpm_status {
-	RPM_INVALID = -1,
 	RPM_ACTIVE = 0,
 	RPM_RESUMING = 1,
 	RPM_SUSPENDED = 2,

--- a/include/bpftune/vmlinux_x86_64.h
+++ b/include/bpftune/vmlinux_x86_64.h
@@ -20733,7 +20733,6 @@ enum rpm_request {
 };
 
 enum rpm_status {
-	RPM_INVALID = -1,
 	RPM_ACTIVE = 0,
 	RPM_RESUMING = 1,
 	RPM_SUSPENDED = 2,


### PR DESCRIPTION
...since they are encoded by clang using kind_flag and kernels < 5.18 rejects BTF enums with kind_flag set.