### PR TITLE
umem tests: fix setting/resetting umem_max

### DIFF
--- a/test/udp_rmem_legacy_test.sh
+++ b/test/udp_rmem_legacy_test.sh
@@ -51,7 +51,7 @@ for FAMILY in $FAMILIES ; do
    test_start "$0|udp rmem legacy test $BW to $ADDR:$PORT $FAMILY $MAX_CONN conn"
 
    rmem_default_orig=$(sysctl -n net.core.rmem_default)
-   rmem_max_orig=$(sysctl -n net.core.rmem_default)
+   rmem_max_orig=$(sysctl -n net.core.rmem_max)
    rmem_test=16384
    sysctl -w net.core.rmem_default=$rmem_test
    sysctl -w net.core.rmem_max=$rmem_test

--- a/test/udp_rmem_locked_test.sh
+++ b/test/udp_rmem_locked_test.sh
@@ -51,7 +51,7 @@ for FAMILY in $FAMILIES ; do
    test_start "$0|udp rmem locked test $BW to $ADDR:$PORT $FAMILY $MAX_CONN conn"
 
    rmem_default_orig=$(sysctl -n net.core.rmem_default)
-   rmem_max_orig=$(sysctl -n net.core.rmem_default)
+   rmem_max_orig=$(sysctl -n net.core.rmem_max)
    rmem_test=16384
    sysctl -w net.core.rmem_default=$rmem_test
    sysctl -w net.core.rmem_max=$rmem_test

--- a/test/udp_rmem_test.sh
+++ b/test/udp_rmem_test.sh
@@ -51,7 +51,7 @@ for FAMILY in $FAMILIES ; do
    test_start "$0|udp rmem test $BW to $ADDR:$PORT $FAMILY $MAX_CONN conn"
 
    rmem_default_orig=$(sysctl -n net.core.rmem_default)
-   rmem_max_orig=$(sysctl -n net.core.rmem_default)
+   rmem_max_orig=$(sysctl -n net.core.rmem_max)
    rmem_test=16384
    sysctl -w net.core.rmem_default=$rmem_test
    sysctl -w net.core.rmem_max=$rmem_test


### PR DESCRIPTION
we were reading umem_max orig value from umem_default, then setting it on cleanup leading to socket mem issues.