### PR TITLE
handle absence of /usr/bin/ulimit on Ubuntu

### DIFF
--- a/test/good_syn_flood_test.sh
+++ b/test/good_syn_flood_test.sh
@@ -93,10 +93,10 @@ for NS in nonglobal global ; do
       service_cmd stop firewalld
    fi
 
-   $SERVER_PREFIX ulimit -n 100000
-   $SERVER_PREFIX ulimit -u 100000
-   $CLIENT_PREFIX ulimit -n 100000
-   $CLIENT_PREFIX ulimit -u 100000
+   $SERVER_PREFIX $ULIMIT -n 100000
+   $SERVER_PREFIX $ULIMIT -u 100000
+   $CLIENT_PREFIX $ULIMIT -n 100000
+   $CLIENT_PREFIX $ULIMIT -u 100000
 
    for MODE in baseline test ; do
 

--- a/test/test_lib.sh
+++ b/test/test_lib.sh
@@ -94,6 +94,7 @@ check_prog "$HPING" hping3 hping3
 export FIREWALL_CMD=$(which firewall-cmd 2>/dev/null)
 export AUDIT_CMD=$(which auditctl 2>/dev/null)
 export JQ_CMD=$(which jq 2>/dev/null)
+export ULIMIT="bash -c ulimit"
 export SYSLOGFILE=${SYSLOGFILE:-"/var/log/messages"}
 export DBPMDA_CMD=$(which dbpmda 2>/dev/null)
 if [[ ! -f $SYSLOGFILE ]]; then


### PR DESCRIPTION
only have shell builtin on Ubuntu, so invoke it via "bash -c ulimit"