### PR TITLE
net_buffer_tuner: set high_order_alloc_disable=0 on newer kernels

### DIFF
--- a/include/bpftune/libbpftune.h
+++ b/include/bpftune/libbpftune.h
@@ -69,6 +69,10 @@
 #define ARRAY_SIZE(arr)			(sizeof(arr) / sizeof((arr)[0])) 
 #endif
 
+#ifndef KERNEL_VERSION
+#define KERNEL_VERSION(a, b, c) (((a) << 16) + ((b) << 8) + ((c) > 255 ? 255 : (c)))
+#endif
+
 #define BPFTUNE_SERVER_MSG_MAX		65536
 
 char *bpftune_state_string[] = {

--- a/src/net_buffer_tuner.h
+++ b/src/net_buffer_tuner.h
@@ -24,6 +24,7 @@ enum net_buffer_tunables {
 	FLOW_LIMIT_CPU_BITMAP,
 	NETDEV_BUDGET,
 	NETDEV_BUDGET_USECS,
+	HIGH_ORDER_ALLOC_DISABLE,
 	NET_BUFFER_NUM_TUNABLES,
 };
 
@@ -32,6 +33,7 @@ enum net_buffer_scenarios {
 	FLOW_LIMIT_CPU_SET,
 	NETDEV_BUDGET_INCREASE,
 	NETDEV_BUDGET_DECREASE,
+	HIGH_ORDER_ALLOC_ENABLE,
 };
 
 /* above 50msec is too high */

--- a/test/Makefile
+++ b/test/Makefile
@@ -37,7 +37,8 @@ NEIGH_TABLE_TESTS =	neigh_table_test neigh_table_v4only_test \
 			neigh_table_max_test neigh_table_max2_test \
 			neigh_table_legacy_test
 
-NET_BUFFER_TESTS =	budget_test backlog_test backlog_legacy_test
+NET_BUFFER_TESTS =	budget_test backlog_test backlog_legacy_test \
+			high_order_alloc_test
 
 TCP_BUFFER_TESTS =	mem_pressure_test mem_pressure_legacy_test \
 			mem_exhaust_test mem_exhaust_legacy_test \

--- a/test/high_order_alloc_test.sh
+++ b/test/high_order_alloc_test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/bash
+#
+# SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note
+#
+# Copyright (c) 2025, Oracle and/or its affiliates.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License v2 as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public
+# License along with this program; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+# Boston, MA 021110-1307, USA.
+#
+
+# run high order alloc test
+
+. ./test_lib.sh
+
+
+SLEEPTIME=10
+
+for TUNER in net_buffer ; do
+
+   test_start "$0|high order alloc test: is high order alloc disabled for kernels > 5.14?"
+
+   test_setup "true"
+
+   orig_high_order=$(sysctl -n net.core.high_order_alloc_disable)
+   sysctl -w net.core.high_order_alloc_disable=1
+
+   test_run_cmd_local "$BPFTUNE -ds &" true
+
+   sleep $SETUPTIME
+
+   expected=1
+
+   case $MAJ_KVER in
+   2|3|4)
+	   ;;
+   5)
+	   if [[ $MIN_KVER -gt 14 ]]; then
+		   expected_high_order=0
+	   fi
+	   ;;
+   *)
+	   expected=0
+	   ;;
+   esac
+
+   val="$(sysctl -qn net.core.high_order_alloc_disable)"
+   pkill -TERM bpftune
+   sysctl -w net.core.high_order_alloc_disable=$orig_high_order
+   if [[ "$val" == "$expected" ]]; then
+	   test_pass
+   fi
+   test_cleanup
+done
+
+test_exit


### PR DESCRIPTION
The documentation for net.core.high_order_alloc_disable says

"By default the allocator for page frags tries to use high order pages (order-3 on x86). While the default behavior gives good results in most cases, some users might have hit a contention in page allocations/freeing. This was especially true on older kernels (< 5.14) when high-order pages were not stored on per-cpu lists. This allows to opt-in for order-0 allocation instead but is now mostly of historical importance."

So we set high_order_alloc_disable=0 on tuner init for kernels >= 5.14.