### PR TITLE
tests: tolerate absence of hping3, lsof

### DIFF
--- a/test/many_netns_test.sh
+++ b/test/many_netns_test.sh
@@ -29,11 +29,13 @@ PORT=5201
 SLEEPTIME=1
 TIMEOUT=30
 
+set +e
 LSOF=$(which lsof 2>/dev/null)
 if [[ -z "$LSOF" ]]; then
      echo "lsof not available, skipping..."
      exit 0
 fi
+set -e
 
 for i in $(seq 1 1000); do
      ip netns add ${NETNS_PREFIX}-extra${i}

--- a/test/syn_flood_test.sh
+++ b/test/syn_flood_test.sh
@@ -23,6 +23,14 @@
 
 . ./test_lib.sh
 
+set +e
+$HPING --help >/dev/null 2>&1
+if [[ $? -ne 0 ]]; then
+	echo "hping ($HPING) unavailable/does not work, skipping test..."
+        exit 0
+fi
+set -e
+
 LOGFILE=$TESTLOG_LAST
 
 SLEEPTIME=1

--- a/test/test_lib.sh
+++ b/test/test_lib.sh
@@ -90,7 +90,6 @@ check_prog "$NC" nc nmap-netcat
 export STRESS_NG=$(which stress-ng 2>/dev/null)
 check_prog "$STRESS_NG" stress-ng stress-ng
 export HPING=$(which hping3 2>/dev/null)
-check_prog "$HPING" hping3 hping3
 export FIREWALL_CMD=$(which firewall-cmd 2>/dev/null)
 export AUDIT_CMD=$(which auditctl 2>/dev/null)
 export JQ_CMD=$(which jq 2>/dev/null)


### PR DESCRIPTION
Tests should drive on when less needed tools are absent; hping3/lsof for syn flood/many_netns tests.  We do this for qperf already as it is not always avaiable.