### PR TITLE
treewide: fix some typos

### DIFF
--- a/sample_tuner/sample_tuner.bpf.c
+++ b/sample_tuner/sample_tuner.bpf.c
@@ -26,7 +26,7 @@ BPF_FENTRY(proc_dostring_coredump, struct ctl_table *table, int write,
 	struct bpftune_event event = {};
 	int ret, scenario_id = 0;
 
-	/* tuner id is a global declared in bpftune.bpf.h and set by bfttune
+	/* tuner id is a global declared in bpftune.bpf.h and set by bpftune
 	 * when the tuner is added.
 	 */
 	event.tuner_id = tuner_id;

--- a/src/tcp_conn_tuner.h
+++ b/src/tcp_conn_tuner.h
@@ -88,7 +88,7 @@ struct remote_host {
 #define RTT_SCALE       1000000
 #define DELIVERY_SCALE  1000000
 
-/* The metric we calcuate compares current connection min_rtt and rate_delivered to
+/* The metric we calculate compares current connection min_rtt and rate_delivered to
  * the min rtt and max rate delivered we have observed for the remote host.
  * The idea is that we want to reward congestion control algorithms that minimize
  * RTT and maximize delivery rate, as these are operating at the bottleneck

--- a/test/strategy/strategy_tuner.bpf.c
+++ b/test/strategy/strategy_tuner.bpf.c
@@ -27,7 +27,7 @@ BPF_FENTRY(proc_dostring_coredump, struct ctl_table *table, int write,
 	struct bpftune_event event = {};
 	int ret, scenario_id = 0;
 
-	/* tuner id is a global declared in bpftune.bpf.h and set by bfttune
+	/* tuner id is a global declared in bpftune.bpf.h and set by bpftune
 	 * when the tuner is added.
 	 */
 	event.tuner_id = tuner_id;
@@ -45,7 +45,7 @@ BPF_FENTRY(proc_dostring, struct ctl_table *table, int write,
 	struct bpftune_event event = {};
 	int ret, scenario_id = 0;
 
-	/* tuner id is a global declared in bpftune.bpf.h and set by bfttune
+	/* tuner id is a global declared in bpftune.bpf.h and set by bpftune
 	 * when the tuner is added.
 	 */
         event.tuner_id = tuner_id;


### PR DESCRIPTION
1. Correct typo 'bfttune' to 'bpftune'
2. Correct typo 'calcuate' to 'calculate'.