### PR TITLE
I picked and fixed 5 niche bugs in oracle/bpftune - all related to incorrect format string usage in C logging code:

### DIFF
--- a/src/libbpftune.c
+++ b/src/libbpftune.c
@@ -101,7 +101,7 @@ void bpftune_log_syslog(__attribute__((unused)) void *ctx, int level,
 
 	buflen = vsnprintf(buf, sizeof(buf), fmt, args);
 	if (buflen > 0)
-		syslog(level, buf, buflen + 1);
+		syslog(level, "%s", buf);
 }
 
 /* log to ctx buffer for specific thread, fall back to usual log destination */
@@ -811,7 +811,7 @@ struct bpftuner *bpftuner_init(const char *path)
 	tuner->id = bpftune_num_tuners;
 	tuner->state = BPFTUNE_ACTIVE;
 	bpftune_tuners[bpftune_num_tuners++] = tuner;
-	bpftune_log(LOG_DEBUG, "sucessfully initialized tuner %s[%d]\n",
+	bpftune_log(LOG_DEBUG, "successfully initialized tuner %s[%d]\n",
 		    tuner->name, tuner->id);
 	return tuner;
 }
@@ -1391,7 +1391,7 @@ int bpftuner_tunables_init(struct bpftuner *tuner, unsigned int num_descs,
 	for (i = 0; i < num_descs; i++) {
 		int num_values;
 
-		bpftune_log(LOG_DEBUG, "handling desc %ld/%ld\n", i, num_descs);
+		bpftune_log(LOG_DEBUG, "handling desc %u/%u\n", i, num_descs);
 		memcpy(&tuner->tunables[i].desc, &descs[i], sizeof(*descs));
 
 		if (descs[i].type != BPFTUNABLE_SYSCTL)
@@ -1414,7 +1414,7 @@ int bpftuner_tunables_init(struct bpftuner *tuner, unsigned int num_descs,
 		}
 		if (num_values != descs[i].num_values) {
 			bpftune_log(LOG_ERR, "error reading tunable '%s'; expected %d values, got %d\n",
-				    descs[i].num_values, num_values);
+				    descs[i].name, descs[i].num_values, num_values);
 			return -EINVAL;
 		}
 		if (descs[i].flags & BPFTUNABLE_STRING) {

--- a/src/neigh_table_tuner.c
+++ b/src/neigh_table_tuner.c
@@ -198,7 +198,7 @@ static int increase_or_decrease_thresh(struct bpftuner *tuner,
 	}
 	ret = nl_connect(sk, NETLINK_ROUTE);
 	if (ret) {
-		bpftune_log(LOG_ERR, "nl_connect() failed: %d\n",
+		bpftune_log(LOG_ERR, "nl_connect() failed: %s\n",
 			    strerror(-ret));
 		goto out;
 	}


### PR DESCRIPTION
### Bugs Fixed

| # | Severity | File | Issue |
|---|----------|------|-------|
| 1 | 🔴 Critical | [libbpftune.c](cci:7://file:///home/kk/Downloads/bpftune/src/libbpftune.c:0:0-0:0) | **Format string vulnerability in [syslog()](cci:1://file:///home/kk/Downloads/bpftune/src/libbpftune.c:95:0-104:1)** — [buf](cci:1://file:///home/kk/Downloads/bpftune/src/libbpftune.c:106:0-125:1) used as format string, causing UB if message contains `%s`/`%n` |
| 2 | 🔴 Critical | [libbpftune.c](cci:7://file:///home/kk/Downloads/bpftune/src/libbpftune.c:0:0-0:0) | **Missing argument** — 3 format specifiers but only 2 args → reading garbage from stack |
| 3 | 🟡 Medium | [neigh_table_tuner.c](cci:7://file:///home/kk/Downloads/bpftune/src/neigh_table_tuner.c:0:0-0:0) | **`%d` for `strerror()` return** — prints pointer as integer instead of error string |
| 4 | 🟢 Low | [libbpftune.c](cci:7://file:///home/kk/Downloads/bpftune/src/libbpftune.c:0:0-0:0) | **`%ld` for `unsigned int`** — technically UB per C standard |
| 5 | 🟢 Low | [libbpftune.c](cci:7://file:///home/kk/Downloads/bpftune/src/libbpftune.c:0:0-0:0) | **Typo**: "sucessfully" → "successfully" |

### What was done
- Created branch `fix/format-string-bugs`
- Made all fixes across 2 files (5 insertions, 5 deletions)
- Committed with signed-off-by as required by the project's OCA policy (TBD)
- Wrote a detailed PR description → see the artifact