### PR TITLE
Timewait reuse autotuning

### DIFF
--- a/docs/bpftune-tcp-conn.rst
+++ b/docs/bpftune-tcp-conn.rst
@@ -127,6 +127,9 @@ DESCRIPTION
         In addition, when retransmits occur for a TCP connection, we enable
         TCP thin linear timeouts to improve responsiveness for thin TCP connections.
 
+        Also we watch out for potential exhaustion of outbound ephemeral ports
+        and set net.ipv4.tcp_rw_reuse=1 if that event is imminent.
+
         References:
 
         BBR: Congestion-Based Congestion Control

--- a/include/bpftune/libbpftune.h
+++ b/include/bpftune/libbpftune.h
@@ -357,6 +357,7 @@ int bpftune_sysctl_write_string(int netns_fd, const char *name, char *val);
 long long bpftune_ksym_addr(char type, const char *name);
 int bpftune_snmpstat_read(unsigned long netns_cookie, int family, const char *linename, const char *name, long *value);
 int bpftune_netstat_read(unsigned long netns_cookie, int family, const char *linename, const char *name, long *value);
+int bpftune_sockstat_read(unsigned long netns_cookie, int family, const char *linename, const char *name, long *value);
 int bpftune_sched_wait_run_percent_read(void);
 bool bpftune_netns_cookie_supported(void);
 unsigned long bpftune_global_netns_cookie(void);

--- a/src/libbpftune.c
+++ b/src/libbpftune.c
@@ -1239,7 +1239,7 @@ out:
 	return ret;
 }
 
-static int bpftune_nstat_read(unsigned long netns_cookie, int family,
+static int bpftune_nstat_read(unsigned long netns_cookie, bool key_val,
 			      const char *file, const char *linename,
 			      const char *name, long *value)
 {
@@ -1268,11 +1268,11 @@ static int bpftune_nstat_read(unsigned long netns_cookie, int family,
 		char *next, *s, *saveptr = NULL;
 		int index = 0;
 
-		/* for IPv6 it is a "key value" format per line; for
-		 * IPv4 it is a set of parameter names on one line
+		/* for key_val it is a "key value" format per line;
+		 * otherwise it is a set of parameter names on one line
 		 * followed by the values on the next.
 		 */
-		if (family == AF_INET6) {
+		if (key_val) {
 			char nextname[128];
 
 			sscanf(line, "%s %ld", nextname, value);
@@ -1321,7 +1321,8 @@ out_unset:
 int bpftune_snmpstat_read(unsigned long netns_cookie, int family,
                           const char *linename, const char *name, long *value)
 {
-	return bpftune_nstat_read(netns_cookie, family,
+	/* for IPv6 format is key value, for IPv4 it is keys on one line, values next. */
+	return bpftune_nstat_read(netns_cookie, family == AF_INET6,
 				  family == AF_INET ? "/proc/net/snmp" :
 				 		      "/proc/net/snmp6",
 				  linename, name, value);
@@ -1330,7 +1331,16 @@ int bpftune_snmpstat_read(unsigned long netns_cookie, int family,
 int bpftune_netstat_read(unsigned long netns_cookie, int family,
 			 const char *linename, const char *name, long *value)
 {
-	return bpftune_nstat_read(netns_cookie, family, "/proc/net/netstat",
+	return bpftune_nstat_read(netns_cookie, family == AF_INET6, "/proc/net/netstat",
+				  linename, name, value);
+}
+
+int bpftune_sockstat_read(unsigned long netns_cookie, int family,
+			   const char *linename, const char *name, long *value)
+{
+	return bpftune_nstat_read(netns_cookie, true,
+				  family == AF_INET ? "/proc/net/sockstat" :
+				  		      "/proc/net/sockstat6",
 				  linename, name, value);
 }
 

--- a/src/libbpftune.map
+++ b/src/libbpftune.map
@@ -61,6 +61,7 @@ LIBBPFTUNE_0.1.1 {
 		bpftune_ksym_addr;
 		bpftune_netstat_read;
 		bpftune_snmpstat_read;
+		bpftune_sockstat_read;
 		bpftune_sched_wait_run_percent_read;
 		bpftune_netns_init_all;
 		bpftune_netns_set;

--- a/src/tcp_conn_tuner.bpf.c
+++ b/src/tcp_conn_tuner.bpf.c
@@ -78,6 +78,52 @@ static __always_inline void set_cong(struct bpf_sock_ops *ops, __u8 i)
 
 __u64 tcp_thin_lto_choices;
 
+__u64 tcp_tw_reuse;
+
+__u64 tcp_active_conn;
+__u64 tcp_active_last;
+
+/*
+ * Send regular events to check if we are accumulating too many timewait
+ * sockets.
+ */
+static __always_inline void tcp_active_conn_update(struct bpf_sock_ops *ops)
+{
+	struct bpftune_event event = { 0 };
+	long reuse_old[3] = { 0 }, reuse_new[3] = { 0 };
+	struct bpf_sock *sk = ops->sk;
+	struct tcp_sock *tp;
+	__u64 active_curr;
+
+	if (tcp_tw_reuse == 1)
+		return;
+
+	/* avoid excessive processing */
+	if ((++tcp_active_conn % TCP_TW_MIN_THRESH) != 0)
+		return;
+	active_curr = bpf_ktime_get_ns();
+	if ((active_curr - tcp_active_last) < MINUTE)
+		return;
+	if (!sk)
+		return;
+	tp = bpf_skc_to_tcp_sock(sk);
+	if (!tp)
+		return;
+
+	reuse_old[0] = tcp_tw_reuse;
+	reuse_new[0] = 1;
+	/* send number of active connections in last minute to inform userspace */
+	reuse_new[1] = tcp_active_conn;
+
+	tcp_active_conn = 0;
+	tcp_active_last = active_curr;
+
+	/* send event to check if we approach limits with active + tw socks */
+	send_sk_sysctl_event((struct sock *)tp,
+			     TCP_TW_REUSE_ENABLE,
+			     TCP_TW_REUSE, reuse_old, reuse_new, &event);
+}
+
 SEC("sockops")
 int bpftune_conn_tuner(struct bpf_sock_ops *ops)
 {
@@ -96,6 +142,8 @@ int bpftune_conn_tuner(struct bpf_sock_ops *ops)
 
 	switch (ops->op) {
 	case BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB:
+		tcp_active_conn_update(ops);
+		/* FALLTHRU */
 	case BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB:
 		/* enable other needed events */
 		bpf_sock_ops_cb_flags_set(ops, cb_flags);

--- a/src/tcp_conn_tuner.c
+++ b/src/tcp_conn_tuner.c
@@ -40,16 +40,19 @@ static struct bpftunable_desc descs[] = {
 { TCP_CONG_DEFAULT, BPFTUNABLE_SYSCTL, "net.ipv4.tcp_congestion_control",
   BPFTUNABLE_NAMESPACED | BPFTUNABLE_STRING, 1 },
 { TCP_THIN_LINEAR_TIMEOUTS, BPFTUNABLE_SYSCTL, "net.ipv4.tcp_thin_linear_timeouts", BPFTUNABLE_NAMESPACED, 1 },
+{ TCP_TW_REUSE, BPFTUNABLE_SYSCTL, "net.ipv4.tcp_tw_reuse", BPFTUNABLE_NAMESPACED, 1 },
+{ NET_IP_LOCAL_PORT_RANGE, BPFTUNABLE_SYSCTL, "net.ipv4.ip_local_port_range", BPFTUNABLE_NAMESPACED, 2 },
 };
 
 static struct bpftunable_scenario scenarios[] = {
 { TCP_CONG_SET,		"specify TCP congestion control algorithm",
   "To optimize TCP performance, a TCP congestion control algorithm was chosen to mimimize round-trip time and maximize delivery rate." },
+{ TCP_TW_REUSE_ENABLE,	"enable TCP timewait reuse",
+  "To avoid outbound exhaustion of TCP ephemeral ports, enable TCP timewait reuse" },
 };
-
 struct tcp_conn_tuner_bpf *skel;
 
-int tcp_iter_fd;
+static long tcp_tw_reuse = 0;
 
 int init(struct bpftuner *tuner)
 {
@@ -113,6 +116,9 @@ int init(struct bpftuner *tuner)
 	t = bpftuner_tunable(tuner, TCP_THIN_LINEAR_TIMEOUTS);
 	if (t)
 		bpftuner_bpf_var_set(tcp_conn, tuner, tcp_thin_lto, t->initial_values[0]);
+	t = bpftuner_tunable(tuner, TCP_TW_REUSE);
+	if (t)
+		bpftuner_bpf_var_set(tcp_conn, tuner, tcp_tw_reuse, t->initial_values[0]);
 out:
 	bpftune_cap_drop();
 	return err;
@@ -182,9 +188,63 @@ void fini(struct bpftuner *tuner)
 	bpftuner_bpf_fini(tuner);
 }
 
-void event_handler(struct bpftuner *tuner,  __attribute__((unused))struct bpftune_event *event,
+static void tcp_tw_reuse_update(struct bpftuner *tuner, unsigned long netns_cookie,
+				int scenario, long est_count)
+{
+	long tw_count = 0, port_range = 0, port_max, port_min, new = 1;
+	int family = AF_INET;
+	struct bpftunable *t;
+
+	if (tcp_tw_reuse == 1)
+		return;
+
+	t = bpftuner_tunable(tuner, NET_IP_LOCAL_PORT_RANGE);
+	if (t) {
+		port_max = t->current_values[1];
+		port_min = t->current_values[0];
+		port_range = port_max - port_min;
+	}
+	if (port_range <= 0)
+		return;
+	if (bpftune_sockstat_read(netns_cookie, family, "TCP", "tw", &tw_count))
+		return;
+
+	bpftune_log(LOG_DEBUG, "TCP tw_count %ld + est_count %ld approaches port range %ld?\n",
+		    tw_count, est_count, port_range);
+	if (!NEARLY_FULL(tw_count + est_count, port_range))
+		return;
+
+	t = bpftuner_tunable(tuner, TCP_TW_REUSE);
+	if (!t)
+		return;
+	tcp_tw_reuse = t->current_values[0];
+
+	if (tcp_tw_reuse == new)
+		return;
+	if (!bpftuner_tunable_sysctl_write(tuner, TCP_TW_REUSE, scenario,
+					   netns_cookie, 1, &new,
+"Due to approaching ephemeral port limit of %ld (%ld - %ld), change %s from %ld -> %ld\n",
+					   port_range, port_max, port_min, 
+					   bpftuner_tunable_name(tuner, TCP_TW_REUSE),
+					   tcp_tw_reuse, new)) {
+		bpftuner_bpf_var_set(tcp_conn, tuner, tcp_tw_reuse, new);
+		tcp_tw_reuse = 1;
+	}
+}
+
+void event_handler(struct bpftuner *tuner,  struct bpftune_event *event,
 		   __attribute__((unused))void *ctx)
 {
-	bpftune_log(LOG_DEBUG,
-		    "%s: got unexpected event\n", tuner->name);
+	int scenario = event->scenario_id;
+
+	switch (scenario) {
+	case TCP_TW_REUSE_ENABLE:
+		tcp_tw_reuse_update(tuner, event->netns_cookie, scenario,
+				    event->update[0].new[1]);
+		break;
+	default:
+		bpftune_log(LOG_DEBUG,
+			    "%s: got unexpected event\n", tuner->name);
+		break;
+	}
 }

--- a/src/tcp_conn_tuner.h
+++ b/src/tcp_conn_tuner.h
@@ -17,17 +17,26 @@
 
 #include <bpftune/bpftune.h>
 
-enum tcp_cong_tunables {
+enum tcp_conn_tunables {
 	TCP_CONG,
 	TCP_ALLOWED_CONG,
 	TCP_AVAILABLE_CONG,
 	TCP_CONG_DEFAULT,
-	TCP_THIN_LINEAR_TIMEOUTS
+	TCP_THIN_LINEAR_TIMEOUTS,
+	TCP_TW_REUSE,
+	NET_IP_LOCAL_PORT_RANGE,
+	TCP_TIMESTAMPS,
 };
 
-enum tcp_cong_scenarios {
+enum tcp_conn_scenarios {
 	TCP_CONG_SET,
+	TCP_TW_REUSE_ENABLE,
 };
+
+/* min threshold of active connections/min to send event checking
+ * for outbound port exhaustion.
+ */
+#define TCP_TW_MIN_THRESH	128
 
 #define CONG_MAXNAME	16
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -47,7 +47,8 @@ TCP_BUFFER_TESTS =	mem_pressure_test mem_pressure_legacy_test \
 			wmem_test wmem_legacy_test \
 			rmem_test rmem_legacy_test
 
-TCP_CONN_TESTS =	cong_test cong_legacy_test \
+TCP_CONN_TESTS =	tw_reuse_netns_test tw_reuse_test tw_reuse_legacy_test \
+			cong_test cong_legacy_test \
 			file_download_test file_download_legacy_test
 
 UDP_BUFFER_TESTS =	udp_rmem_test udp_rmem_legacy_test \

--- a/test/tw_reuse_legacy_test.sh
+++ b/test/tw_reuse_legacy_test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/bash
+#
+# SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note
+#
+# Copyright (c) 2026, Oracle and/or its affiliates.
+
+PORT=5201
+CONN_COUNT=${CONN_COUNT:-128}
+PORT_MIN=40000
+PORT_MAX=$((PORT_MIN + CONN_COUNT - 1))
+
+. ./test_lib.sh
+
+LOGFILE=$TESTLOG_LAST
+TIMEOUT=90
+SLEEPTIME=1
+
+restore_tw_reuse_sysctls()
+{
+	set +e
+	if [[ ${#port_range_orig[@]} -eq 2 ]]; then
+		sysctl -qw net.ipv4.ip_local_port_range="${port_range_orig[0]} ${port_range_orig[1]}"
+	fi
+	if [[ -n "${tw_reuse_orig:-}" ]]; then
+		sysctl -qw net.ipv4.tcp_tw_reuse=$tw_reuse_orig
+	fi
+	if [[ -n "${timestamps_orig:-}" ]]; then
+		sysctl -qw net.ipv4.tcp_timestamps=$timestamps_orig
+	fi
+	set -e
+}
+
+tw_reuse_cleanup_exit()
+{
+	restore_tw_reuse_sysctls
+	test_cleanup_exit
+}
+
+test_start "$0|tcp_tw_reuse test with $CONN_COUNT outbound connections and $CONN_COUNT ephemeral ports"
+
+tw_reuse_orig=$(sysctl -n net.ipv4.tcp_tw_reuse)
+timestamps_orig=$(sysctl -n net.ipv4.tcp_timestamps)
+port_range_orig=($(sysctl -n net.ipv4.ip_local_port_range))
+
+test_setup true
+trap tw_reuse_cleanup_exit EXIT
+
+sysctl -qw net.ipv4.tcp_tw_reuse=0
+sysctl -qw net.ipv4.tcp_timestamps=1
+sysctl -qw net.ipv4.ip_local_port_range="$PORT_MIN $PORT_MAX"
+
+test_run_cmd_local "ip netns exec $NETNS ./conn_bomb -l $VETH1_IPV4 -p $PORT -b $CONN_COUNT -C $CONN_COUNT -c 1 -m twreuse -q -t $TIMEOUT &" true
+sleep $SLEEPTIME
+test_run_cmd_local "$BPFTUNE -Lda tcp_conn_tuner.so -s &" true
+sleep $SETUPTIME
+
+set +e
+test_run_cmd_local "./conn_bomb -r $VETH1_IPV4 -P $PORT -C $CONN_COUNT -c 1 -m twreuse -q -t $TIMEOUT" true
+set -e
+
+sleep $SETUPTIME
+tw_reuse_post=$(sysctl -n net.ipv4.tcp_tw_reuse)
+pkill -TERM bpftune || true
+# ensures timewait sockets expire for next test
+sleep 60
+
+grep "tcp_tw_reuse" $LOGFILE
+
+if [[ "$tw_reuse_post" -ne 1 ]]; then
+	echo "expected net.ipv4.tcp_tw_reuse to be 1, is $tw_reuse_post"
+	test_cleanup
+fi
+
+restore_tw_reuse_sysctls
+test_pass
+
+test_cleanup
+
+test_exit

--- a/test/tw_reuse_netns_test.sh
+++ b/test/tw_reuse_netns_test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/bash
+#
+# SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note
+#
+# Copyright (c) 2026, Oracle and/or its affiliates.
+
+PORT=5201
+CONN_COUNT=${CONN_COUNT:-128}
+PORT_MIN=40000
+PORT_MAX=$((PORT_MIN + CONN_COUNT - 1))
+
+. ./test_lib.sh
+
+LOGFILE=$TESTLOG_LAST
+TIMEOUT=90
+SLEEPTIME=1
+
+test_start "$0|tcp_tw_reuse test with $CONN_COUNT outbound connections and $CONN_COUNT ephemeral ports"
+
+test_setup true
+
+ip netns exec $NETNS sysctl -qw net.ipv4.tcp_tw_reuse=0
+ip netns exec $NETNS sysctl -qw net.ipv4.tcp_timestamps=1
+ip netns exec $NETNS sysctl -qw net.ipv4.ip_local_port_range="$PORT_MIN $PORT_MAX"
+
+test_run_cmd_local "./conn_bomb -l $VETH2_IPV4 -p $PORT -b $CONN_COUNT -C $CONN_COUNT -c 1 -m twreuse -q -t $TIMEOUT &" true
+sleep $SLEEPTIME
+test_run_cmd_local "$BPFTUNE -da tcp_conn_tuner.so -s &" true
+sleep $SETUPTIME
+
+set +e
+test_run_cmd_local "ip netns exec $NETNS ./conn_bomb -r $VETH2_IPV4 -P $PORT -C $CONN_COUNT -c 1 -m twreuse -q -t $TIMEOUT" true
+set -e
+
+sleep $SETUPTIME
+tw_reuse_post=$(ip netns exec $NETNS sysctl -n net.ipv4.tcp_tw_reuse)
+pkill -TERM bpftune || true
+# ensures timewait sockets expire for next test
+sleep $SLEEPTIME
+
+grep "tcp_tw_reuse" $LOGFILE
+
+if [[ "$tw_reuse_post" -ne 1 ]]; then
+	echo "expected net.ipv4.tcp_tw_reuse to be 1, is $tw_reuse_post"
+	test_cleanup
+fi
+
+test_pass
+test_cleanup
+
+test_exit

--- a/test/tw_reuse_test.sh
+++ b/test/tw_reuse_test.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/bash
+#
+# SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note
+#
+# Copyright (c) 2026, Oracle and/or its affiliates.
+
+PORT=5201
+CONN_COUNT=${CONN_COUNT:-128}
+PORT_MIN=40000
+PORT_MAX=$((PORT_MIN + CONN_COUNT - 1))
+
+. ./test_lib.sh
+
+LOGFILE=$TESTLOG_LAST
+TIMEOUT=90
+SLEEPTIME=1
+
+restore_tw_reuse_sysctls()
+{
+	set +e
+	if [[ ${#port_range_orig[@]} -eq 2 ]]; then
+		sysctl -qw net.ipv4.ip_local_port_range="${port_range_orig[0]} ${port_range_orig[1]}"
+	fi
+	if [[ -n "${tw_reuse_orig:-}" ]]; then
+		sysctl -qw net.ipv4.tcp_tw_reuse=$tw_reuse_orig
+	fi
+	if [[ -n "${timestamps_orig:-}" ]]; then
+		sysctl -qw net.ipv4.tcp_timestamps=$timestamps_orig
+	fi
+	set -e
+}
+
+tw_reuse_cleanup_exit()
+{
+	restore_tw_reuse_sysctls
+	test_cleanup_exit
+}
+
+test_start "$0|tcp_tw_reuse test with $CONN_COUNT outbound connections and $CONN_COUNT ephemeral ports"
+
+tw_reuse_orig=$(sysctl -n net.ipv4.tcp_tw_reuse)
+timestamps_orig=$(sysctl -n net.ipv4.tcp_timestamps)
+port_range_orig=($(sysctl -n net.ipv4.ip_local_port_range))
+
+test_setup true
+trap tw_reuse_cleanup_exit EXIT
+
+sysctl -qw net.ipv4.tcp_tw_reuse=0
+sysctl -qw net.ipv4.tcp_timestamps=1
+sysctl -qw net.ipv4.ip_local_port_range="$PORT_MIN $PORT_MAX"
+
+test_run_cmd_local "ip netns exec $NETNS ./conn_bomb -l $VETH1_IPV4 -p $PORT -b $CONN_COUNT -C $CONN_COUNT -c 1 -m twreuse -q -t $TIMEOUT &" true
+sleep $SLEEPTIME
+test_run_cmd_local "$BPFTUNE -da tcp_conn_tuner.so -s &" true
+sleep $SETUPTIME
+
+set +e
+test_run_cmd_local "./conn_bomb -r $VETH1_IPV4 -P $PORT -C $CONN_COUNT -c 1 -m twreuse -q -t $TIMEOUT" true
+set -e
+
+sleep $SETUPTIME
+tw_reuse_post=$(sysctl -n net.ipv4.tcp_tw_reuse)
+pkill -TERM bpftune || true
+# ensures timewait sockets expire for next test
+sleep 60
+
+grep "tcp_tw_reuse" $LOGFILE
+
+if [[ "$tw_reuse_post" -ne 1 ]]; then
+	echo "expected net.ipv4.tcp_tw_reuse to be 1, is $tw_reuse_post"
+	test_cleanup
+fi
+
+restore_tw_reuse_sysctls
+test_pass
+test_cleanup
+
+test_exit


### PR DESCRIPTION
 tcp_conn_tuner: auto-tune TCP timewait reuse (net.ipv4.tcp_tw_reuse)
    
Usually net.ipv4.tcp_tw_reuse is set to 2 (reuse TCP timewait sockets for loopback); if we approach limit of outbound ephemeral port exhaustion (timewait_sockets + active_established_sockets approaches port range), set tcp_tw_reuse = 1.

Add tests and document new tcp_conn_tuner behaviour.