### PR TITLE
bpftune: validate plugin paths before loading shared objects

### DIFF
--- a/docs/bpftune.rst
+++ b/docs/bpftune.rst
@@ -14,7 +14,8 @@ SYNOPSIS
 
 	*OPTIONS* := { { **-V** | **--version** } | { **-h** | **--help** }
 	| { [**-s** | **--stderr** } | { [**-c** | **--cgroup**] cgroup} |
-        { [**-l** | **--libdir** ] libdir} | [{ **-d** | **--debug** }] }
+        { [**-l** | **--libdir** ] libdir} | { **--print-libdir** }
+        | [{ **-d** | **--debug** }] }
         { [**-r** | **--learning_rate** ] learning_rate}
         { [**-R** | **--rollback** ]}
         { [**-S** | **--support** ]}
@@ -59,11 +60,17 @@ OPTIONS
         -S, --support
                   Scan system to see what level of bpftune support is present.
         -l, --libdir
-                  bptune extra plugin directory; defaults to
+                  bpftune extra plugin directory; defaults to
                   /usr/local/lib64/bpftune . Both /usr/lib64/bpftune and
                   /usr/local/lib64/bpftune can be used to install plugin tuners;
                   if an alternative to /usr/local/lib64/bpftune is wanted,
-                  it must be specified via library path.
+                  it must be specified via library path. Plugin directories must
+                  be absolute paths whose components and plugin
+                  files are root-owned, are not group- or other-writable, and
+                  have no POSIX ACLs. Symbolic links are rejected.
+
+        --print-libdir
+                  Print the compiled-in standard plugin directory and exit.
 
         -r, --learning_rate
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -40,7 +40,19 @@ endif
 SBINDIR = $(shell basename $(SBINPATH))
 DESTDIR ?= /
 prefix ?= /usr
-libdir ?= lib64
+PKG_CONFIG ?= pkg-config
+LIBBPF_LIBDIR := $(shell $(PKG_CONFIG) --variable=libdir libbpf 2>/dev/null)
+
+# Prefer the ABI-specific library directory reported by libbpf when it is
+# below our install prefix (for example, lib/x86_64-linux-gnu on Debian).
+# Distribution packages and cross-builds can still override libdir explicitly.
+ifneq ($(filter $(prefix)/%,$(LIBBPF_LIBDIR)),)
+DEFAULT_LIBDIR := $(patsubst $(prefix)/%,%,$(LIBBPF_LIBDIR))
+else
+DEFAULT_LIBDIR := lib64
+endif
+
+libdir ?= $(DEFAULT_LIBDIR)
 installprefix = $(DESTDIR)/$(prefix)
 
 INSTALLPATH = $(installprefix)

--- a/src/bpftune.c
+++ b/src/bpftune.c
@@ -111,15 +111,34 @@ void *inotify_thread(void *arg)
 		return NULL;
 	}
 	wd = inotify_add_watch(inotify_fd, library_dir, IN_CREATE | IN_DELETE);
+	if (wd < 0) {
+		bpftune_log(BPFTUNE_LOG_LEVEL,
+			    "cannot monitor '%s' for changes: %s\n", library_dir,
+			    strerror(errno));
+		bpftune_cap_drop();
+		close(inotify_fd);
+		return NULL;
+	}
 
 	bpftune_cap_drop();
 
 	while (!exiting) {
 		len = read(inotify_fd, buf, sizeof(buf));
+		if (len < 0) {
+			if (errno == EINTR)
+				continue;
+			bpftune_log(BPFTUNE_LOG_LEVEL,
+				    "cannot read changes for '%s': %s\n", library_dir,
+				    strerror(errno));
+			break;
+		}
 
-		for (i = 0; i < len; i += sizeof(struct inotify_event)) {
+		for (i = 0; i < len; ) {
 			struct inotify_event *event = (struct inotify_event *)&buf[i];
 			char *suffix;
+			int event_len = sizeof(*event) + event->len;
+
+			i += event_len;
 
 			if (event->mask & IN_ISDIR)
 				continue;
@@ -153,7 +172,6 @@ void *inotify_thread(void *arg)
 		inotify_rm_watch(inotify_fd, wd);
 	bpftune_cap_drop();
 	close(inotify_fd);
-
 	return NULL;
 }
 
@@ -213,9 +231,10 @@ int init(const char *library_dir)
 	}
 
 	if (pthread_attr_init(&attr) ||
-	    pthread_create(&inotify_tid, &attr, inotify_thread, (void *)library_dir))
+	    pthread_create(&inotify_tid, &attr, inotify_thread, (void *)library_dir)) {
 		bpftune_log(LOG_ERR, "could not create inotify thread: %s\n",
 			    strerror(errno));
+	}
 
 	if (ringbuf_map_fd > 0) {
 		ring_buffer = bpftune_ring_buffer_init(ringbuf_map_fd, NULL);
@@ -296,6 +315,7 @@ int main(int argc, char *argv[])
 		{ "libdir",	required_argument,	NULL,	'l' },
 		{ "learning_rate", required_argument,	NULL,	'r' },
 		{ "port",	required_argument,	NULL,	'p' },
+		{ "print-libdir", no_argument,		NULL,	'P' },
 		{ "query",	required_argument,	NULL,	'q' },
 		{ "rollback",	no_argument,		NULL,	'R' },
 		{ "stderr", 	no_argument,		NULL,	's' },
@@ -319,7 +339,7 @@ int main(int argc, char *argv[])
 
 	bin_name = argv[0];
 
-	while ((opt = getopt_long(argc, argv, "a:c:dDhl:Lr:p:q:RsSV", options, NULL))
+	while ((opt = getopt_long(argc, argv, "a:c:dDhl:Lr:p:Pq:RsSV", options, NULL))
 		>= 0) {
 		switch (opt) {
 		case 'a':
@@ -358,6 +378,9 @@ int main(int argc, char *argv[])
 		case 'p':
 			port = (unsigned short)atoi(optarg);
 			break;
+		case 'P':
+			printf("%s\n", BPFTUNER_LIB_DIR);
+			return 0;
 		case 'q':
 			query = optarg;
 			client = true;
@@ -447,7 +470,7 @@ int main(int argc, char *argv[])
 			    BPFTUNER_LIB_DIR, strerror(-err));
 		exit(EXIT_FAILURE);
 	}
-	/* optional dir absence will not trigger failure */
+	/* Optional directories are always an executable-code source. */
 	if (library_dir)
 		init(library_dir);
 

--- a/src/libbpftune.c
+++ b/src/libbpftune.c
@@ -43,6 +43,7 @@
 #include <sched.h>
 #include <mntent.h>
 #include <sys/capability.h>
+#include <sys/xattr.h>
 #include <pthread.h>
 #include <signal.h>
 #include <time.h>
@@ -743,10 +744,11 @@ unsigned long bpftune_global_netns_cookie(void)
 /* add a tuner to the list of tuners, or replace existing inactive tuner.
  * If successful, call init().
  */
-struct bpftuner *bpftuner_init(const char *path)
+static struct bpftuner *__bpftuner_init(const char *path, int fd)
 {
 	struct bpftuner *tuner = NULL;
 	int err, retries;
+	char fd_path[64];
 
 	tuner = calloc(1, sizeof(*tuner));
 	if (!tuner) {
@@ -754,13 +756,16 @@ struct bpftuner *bpftuner_init(const char *path)
 		return NULL;
 	}
 	tuner->name = path;
+	if (fd >= 0)
+		snprintf(fd_path, sizeof(fd_path), "/proc/self/fd/%d", fd);
 
 	bpftune_cap_add();
 	/* if file appears via inotify we may get "file too short" errors;
 	 * retry a few times to avoid this.
 	 */
 	for (retries = 0; retries < 5; retries++) {
-		tuner->handle = dlopen(path, RTLD_NOW | RTLD_GLOBAL);
+		tuner->handle = dlopen(fd >= 0 ? fd_path : path,
+				       RTLD_NOW | RTLD_GLOBAL);
 		if (tuner->handle)
 			break;
 		usleep(1000);
@@ -814,6 +819,133 @@ struct bpftuner *bpftuner_init(const char *path)
 	bpftune_log(LOG_DEBUG, "sucessfully initialized tuner %s[%d]\n",
 		    tuner->name, tuner->id);
 	return tuner;
+}
+
+static bool root_controlled_dir(const char *path)
+{
+	struct stat st;
+	ssize_t acl_size;
+
+	if (lstat(path, &st)) {
+		bpftune_log(LOG_ERR, "cannot stat plugin directory '%s': %s\n",
+			    path, strerror(errno));
+		return false;
+	}
+	if (!S_ISDIR(st.st_mode) || st.st_uid != 0 ||
+	    (st.st_mode & (S_IWGRP | S_IWOTH))) {
+		bpftune_log(LOG_ERR,
+			    "untrusted plugin directory '%s' (mode %o, uid %u)\n",
+			    path, st.st_mode & 07777, st.st_uid);
+		return false;
+	}
+	acl_size = lgetxattr(path, "system.posix_acl_access", NULL, 0);
+	if (acl_size >= 0) {
+		bpftune_log(LOG_ERR, "plugin directory '%s' has an access ACL\n",
+			    path);
+		return false;
+	}
+	if (errno != ENODATA && errno != ENOTSUP && errno != EOPNOTSUPP) {
+		bpftune_log(LOG_ERR, "cannot inspect ACL for plugin directory '%s': %s\n",
+			    path, strerror(errno));
+		return false;
+	}
+	acl_size = lgetxattr(path, "system.posix_acl_default", NULL, 0);
+	if (acl_size >= 0) {
+		bpftune_log(LOG_ERR, "plugin directory '%s' has a default ACL\n",
+			    path);
+		return false;
+	}
+	if (errno != ENODATA && errno != ENOTSUP && errno != EOPNOTSUPP) {
+		bpftune_log(LOG_ERR, "cannot inspect ACL for plugin directory '%s': %s\n",
+			    path, strerror(errno));
+		return false;
+	}
+	return true;
+}
+
+static bool trusted_plugin_path(const char *path)
+{
+	char directory[PATH_MAX];
+	char component[PATH_MAX] = "/";
+	char *cursor, *next;
+	char *slash;
+
+	if (!path || path[0] != '/' || strlen(path) >= sizeof(directory))
+		return false;
+	strcpy(directory, path);
+	slash = strrchr(directory, '/');
+	if (!slash || !slash[1] || !strcmp(slash + 1, ".") ||
+	    !strcmp(slash + 1, ".."))
+		return false;
+	*slash = '\0';
+	if (!directory[0])
+		return false;
+	while (strlen(directory) > 1 && directory[strlen(directory) - 1] == '/')
+		directory[strlen(directory) - 1] = '\0';
+	for (cursor = directory + 1; *cursor; cursor = next + 1) {
+		next = strchr(cursor, '/');
+		if (!next)
+			next = cursor + strlen(cursor);
+		if (next == cursor || (next - cursor == 1 && cursor[0] == '.') ||
+		    (next - cursor == 2 && cursor[0] == '.' && cursor[1] == '.'))
+			return false;
+		if (strlen(component) + (size_t)(next - cursor) + 2 > sizeof(component))
+			return false;
+		if (strcmp(component, "/"))
+			strcat(component, "/");
+		strncat(component, cursor, (size_t)(next - cursor));
+		if (!root_controlled_dir(component))
+			return false;
+		if (!*next)
+			break;
+	}
+	return true;
+}
+
+struct bpftuner *bpftuner_init(const char *path)
+{
+	struct stat st;
+	ssize_t acl_size;
+	int fd, acl_err = 0;
+	struct bpftuner *tuner;
+
+	if (!trusted_plugin_path(path)) {
+		bpftune_log(LOG_ERR, "refusing untrusted plugin '%s'\n", path);
+		return NULL;
+	}
+	fd = open(path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+	acl_size = fd >= 0 ? fgetxattr(fd, "system.posix_acl_access", NULL, 0) : -1;
+	if (acl_size < 0)
+		acl_err = errno;
+	if (fd < 0 || fstat(fd, &st)) {
+		bpftune_log(LOG_ERR, "cannot inspect plugin '%s': %s\n", path,
+			    strerror(errno));
+		goto untrusted;
+	}
+	if (!S_ISREG(st.st_mode) || st.st_uid != 0 ||
+	    (st.st_mode & (S_IWGRP | S_IWOTH))) {
+		bpftune_log(LOG_ERR, "untrusted plugin '%s' (mode %o, uid %u)\n",
+			    path, st.st_mode & 07777, st.st_uid);
+		goto untrusted;
+	}
+	if (acl_size >= 0) {
+		bpftune_log(LOG_ERR, "plugin '%s' has an access ACL\n", path);
+		goto untrusted;
+	}
+	if (acl_err != ENODATA && acl_err != ENOTSUP && acl_err != EOPNOTSUPP) {
+		bpftune_log(LOG_ERR, "cannot inspect ACL for plugin '%s': %s\n",
+			    path, strerror(acl_err));
+		goto untrusted;
+	}
+	tuner = __bpftuner_init(path, fd);
+	close(fd);
+	return tuner;
+
+untrusted:
+	if (fd >= 0)
+		close(fd);
+	bpftune_log(LOG_ERR, "refusing untrusted plugin '%s'\n", path);
+	return NULL;
 }
 
 static void __bpftuner_scenario_log(struct bpftuner *tuner, unsigned int tunable,

--- a/test/Makefile
+++ b/test/Makefile
@@ -21,7 +21,7 @@
 PERF_TESTS = stress_ng_test iperf3_test qperf_test
 
 GENERAL_TESTS =	support_test log_test service_test inotify_test cap_test \
-		sample_test sample_legacy_test \
+		plugin_path_test sample_test sample_legacy_test \
 		strategy_test strategy_legacy_test \
 		rollback_test rollback_legacy_test \
 		query_test rate_test \

--- a/test/inotify_test.sh
+++ b/test/inotify_test.sh
@@ -24,7 +24,7 @@
 . ./test_lib.sh
 
 
-SLEEPTIME=10
+SLEEPTIME=20
 
 for TUNER in neigh_table ; do
 
@@ -36,15 +36,15 @@ for TUNER in neigh_table ; do
 
    sleep $SETUPTIME
 
+   cp -f ${BPFTUNE_LIBDIR}/tcp_buffer_tuner.so /tmp
+   rm ${BPFTUNE_LIBDIR}/tcp_buffer_tuner.so
+
    sleep $SLEEPTIME
-   cp /usr/lib64/bpftune/tcp_buffer_tuner.so /tmp
-   rm /usr/lib64/bpftune/tcp_buffer_tuner.so
-   
    grep "fini tuner" $TESTLOG_LAST
 
-   sleep $SLEEPTIME
-
-   cp /tmp/tcp_buffer_tuner.so /usr/lib64/bpftune
+   install -o root -g root -m 0755 /tmp/tcp_buffer_tuner.so \
+      ${BPFTUNE_LIBDIR}/tcp_buffer_tuner.so
+   rm -f /tmp/tcp_buffer_tuner.so
 
    sleep $SLEEPTIME
    grep "added lib" $TESTLOG_LAST

--- a/test/plugin_path_test.sh
+++ b/test/plugin_path_test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/bash
+#
+# SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note
+#
+# Copyright (c) 2026, Oracle and/or its affiliates.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public
+# License v2 as published by the Free Software Foundation.
+#
+
+# Verify that a valid tuner in a directory with an untrusted ancestor is not
+# loaded. /tmp is normally world-writable, even though this test creates the
+# child directory as root.
+
+. ./test_lib.sh
+
+export SLEEPTIME=20
+
+UNTRUSTED_DIR=$(mktemp -d /tmp/bpftune-untrusted.XXXXXX)
+UNTRUSTED_TUNER="${UNTRUSTED_DIR}/untrusted_tuner.so"
+
+test_start "$0|plugin path test: reject tuner from an untrusted directory"
+test_setup "true"
+
+cp ${BPFTUNE_LIBDIR}/tcp_buffer_tuner.so "$UNTRUSTED_TUNER"
+# Do not use -a here: it filters the mandatory packaged tuners, causing
+# bpftune to exit before it scans the optional -l directory.
+test_run_cmd_local "$BPFTUNE -dsl $UNTRUSTED_DIR &" true
+sleep $SLEEPTIME
+grep "refusing untrusted plugin" "$TESTLOG_LAST"
+
+rm -rf "$UNTRUSTED_DIR"
+test_pass
+test_cleanup
+test_exit

--- a/test/strategy_legacy_test.sh
+++ b/test/strategy_legacy_test.sh
@@ -25,6 +25,7 @@
 
 
 SLEEPTIME=10
+STRATEGY_DIR=/var/lib/bpftune-test/strategy
 
 
 test_start "$0|strategy legacy test: does strategy tuner appear, trigger event and change strategies?"
@@ -32,7 +33,9 @@ test_start "$0|strategy legacy test: does strategy tuner appear, trigger event a
 test_setup "true"
 
 sleep 1
-test_run_cmd_local "$BPFTUNE -dsLl ./strategy &" true
+install -d -o root -g root -m 0755 "$STRATEGY_DIR"
+install -o root -g root -m 0644 strategy/strategy_tuner.so "$STRATEGY_DIR"
+test_run_cmd_local "$BPFTUNE -dsLl $STRATEGY_DIR &" true
 sleep $SETUPTIME
 # trigger event
 sysctl kernel.core_pattern
@@ -43,6 +46,7 @@ sleep 30
 sysctl kernel.core_pattern
 sleep $SLEEPTIME
 grep -E "event .* for tuner strategy, strategy strategy_B" $TESTLOG_LAST
+rm -rf "$STRATEGY_DIR"
 test_pass
 test_cleanup
 test_exit

--- a/test/strategy_test.sh
+++ b/test/strategy_test.sh
@@ -25,6 +25,7 @@
 
 
 SLEEPTIME=10
+STRATEGY_DIR=/var/lib/bpftune-test/strategy
 
 
 test_start "$0|strategy test: does strategy tuner appear, trigger event and change strategies?"
@@ -32,7 +33,9 @@ test_start "$0|strategy test: does strategy tuner appear, trigger event and chan
 test_setup "true"
 
 sleep 1
-test_run_cmd_local "$BPFTUNE -dsl ./strategy &" true
+install -d -o root -g root -m 0755 "$STRATEGY_DIR"
+install -o root -g root -m 0644 strategy/strategy_tuner.so "$STRATEGY_DIR"
+test_run_cmd_local "$BPFTUNE -dsl $STRATEGY_DIR &" true
 sleep $SETUPTIME
 # trigger event
 sysctl kernel.core_pattern
@@ -43,6 +46,7 @@ sleep 30
 sysctl kernel.core_pattern
 sleep $SLEEPTIME
 grep -E "event .* for tuner strategy, strategy strategy_B" $TESTLOG_LAST
+rm -rf "$STRATEGY_DIR"
 test_pass
 test_cleanup
 test_exit

--- a/test/test_lib.sh
+++ b/test/test_lib.sh
@@ -183,6 +183,7 @@ if [[ "$DEBUG" != 0 ]]; then
 fi
 export CGROUPDIR=${CGROUPDIR:-"/var/run/bpftune/cgroupv2"}
 export BPFTUNE_PROG=${BPFTUNE_PROG:-"/usr/sbin/bpftune"}
+export BPFTUNE_LIBDIR="$($BPFTUNE_PROG --print-libdir)"
 export BPFTUNE="${BPFTUNE_PROG} -c $CGROUPDIR $BPFTUNE_FLAGS"
 export BPFTUNE_CMD=${BPFTUNE_CMD:-"$BPFTUNE"}
 
@@ -335,8 +336,10 @@ test_cleanup_local()
 	sysctl -w net.ipv6.conf.all.disable_ipv6=0
 	rm -fr $SERVERDIR
 	set -e
-	if [[ ! -f /usr/lib64/bpftune/tcp_buffer_tuner.so ]]; then
-		mv /tmp/tcp_buffer_tuner.so /usr/lib64/bpftune
+	if [[ ! -f ${BPFTUNE_LIBDIR}/tcp_buffer_tuner.so ]]; then
+		install -o root -g root -m 0755 /tmp/tcp_buffer_tuner.so \
+			${BPFTUNE_LIBDIR}/tcp_buffer_tuner.so
+		rm -f /tmp/tcp_buffer_tuner.so
 	fi
 	if [[ $EXIT -ne 0 ]]; then
 		if [[ -f $TESTLOG_LAST ]]; then


### PR DESCRIPTION
Require root-controlled plugin directories and tuner files before dlopen. Reject writable path components, unsafe ownership, POSIX ACLs, and symlinks; load approved plugins through an already-open file descriptor to prevent replacement races.

Add a regression test ensuring a valid tuner copied beneath /tmp is refused. Update strategy tests to stage plugins in a root-controlled directory.

Derive the default library directory from libbpf pkg-config metadata while preserving explicit package and cross-build libdir overrides. Add --print-libdir so users and tests can query the compiled-in plugin path.

Reported-by: Pragathiswaar AK <pragathiswaar@gmail.com>